### PR TITLE
Format with clang-format in future

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,118 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Format entire project according to .clang-format style definition
+3ca20048ee7fb552625c43fc5c52d6554cb7dc1c

--- a/callbacks.c
+++ b/callbacks.c
@@ -20,14 +20,14 @@
 
 #include <config.h>
 
+#include <gtk/gtk.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <gtk/gtk.h>
 
 #include "callbacks.h"
-#include "main.h"
 #include "gettext.h"
+#include "main.h"
 #define _(String) gettext(String)
 
 GdkColor fgcolors[COLOR_MAX];
@@ -39,208 +39,195 @@ int fg_count = COLOR_WHITE;
 static GtkWidget *mainwin = NULL;
 static struct test_ops *current_test = &basic_ops;
 
-G_MODULE_EXPORT void
-on_mainwin_realize(GtkWidget * widget, G_GNUC_UNUSED gpointer user_data)
-{
-	gint i;
+G_MODULE_EXPORT void on_mainwin_realize(GtkWidget *widget,
+                                        G_GNUC_UNUSED gpointer user_data) {
+  gint i;
 
 #ifndef DEBUG
-	gtk_window_fullscreen(GTK_WINDOW(widget));
+  gtk_window_fullscreen(GTK_WINDOW(widget));
 #endif
 
-	memset(fgcolors, 0, COLOR_MAX * sizeof(GdkColor));
+  memset(fgcolors, 0, COLOR_MAX * sizeof(GdkColor));
 
-	fgcolors[COLOR_WHITE].red = fgcolors[COLOR_WHITE].green =
-		fgcolors[COLOR_WHITE].blue = 65535;
+  fgcolors[COLOR_WHITE].red = fgcolors[COLOR_WHITE].green =
+      fgcolors[COLOR_WHITE].blue = 65535;
 
-	fgcolors[COLOR_RED].red = 65535;
+  fgcolors[COLOR_RED].red = 65535;
 
-	fgcolors[COLOR_GREEN].green = 65535;
+  fgcolors[COLOR_GREEN].green = 65535;
 
-	fgcolors[COLOR_BLUE].blue = 65535;
+  fgcolors[COLOR_BLUE].blue = 65535;
 
-	fgcolors[COLOR_CYAN].green = 65535;
-	fgcolors[COLOR_CYAN].blue = 65535;
+  fgcolors[COLOR_CYAN].green = 65535;
+  fgcolors[COLOR_CYAN].blue = 65535;
 
-	fgcolors[COLOR_MAGENTA].red = 65535;
-	fgcolors[COLOR_MAGENTA].blue = 65535;
+  fgcolors[COLOR_MAGENTA].red = 65535;
+  fgcolors[COLOR_MAGENTA].blue = 65535;
 
-	fgcolors[COLOR_YELLOW].red = 65535;
-	fgcolors[COLOR_YELLOW].green = 65535;
+  fgcolors[COLOR_YELLOW].red = 65535;
+  fgcolors[COLOR_YELLOW].green = 65535;
 
-	/* COLOR_BLACK is 0 already */
+  /* COLOR_BLACK is 0 already */
 
-	fg_color = gdk_color_copy(&fgcolors[COLOR_WHITE]);
-	bg_color = gdk_color_copy(&fgcolors[COLOR_BLACK]);
+  fg_color = gdk_color_copy(&fgcolors[COLOR_WHITE]);
+  bg_color = gdk_color_copy(&fgcolors[COLOR_BLACK]);
 
-	for (i = 0; i < GRAYS_MAX; i++)
-		grays[i].red = grays[i].green = grays[i].blue = i *
-			((1 << 16) - 1) / (GRAYS_MAX - 1);
+  for (i = 0; i < GRAYS_MAX; i++)
+    grays[i].red = grays[i].green = grays[i].blue =
+        i * ((1 << 16) - 1) / (GRAYS_MAX - 1);
 
-	mainwin = widget;
+  mainwin = widget;
 
-	gc = gdk_gc_new(gtk_widget_get_window(mainwin));
-	backgc = gdk_gc_new(gtk_widget_get_window(mainwin));
+  gc = gdk_gc_new(gtk_widget_get_window(mainwin));
+  backgc = gdk_gc_new(gtk_widget_get_window(mainwin));
 
-	if (current_test->init != NULL)
-		current_test->init(widget);
+  if (current_test->init != NULL)
+    current_test->init(widget);
 }
 
-static void update_fg_color(void)
-{
-	gdk_gc_set_rgb_fg_color(gc, fg_color);
-	gdk_gc_set_rgb_bg_color(backgc, fg_color);
+static void update_fg_color(void) {
+  gdk_gc_set_rgb_fg_color(gc, fg_color);
+  gdk_gc_set_rgb_bg_color(backgc, fg_color);
 
-	gdk_window_invalidate_rect(gtk_widget_get_window(mainwin), NULL, FALSE);
+  gdk_window_invalidate_rect(gtk_widget_get_window(mainwin), NULL, FALSE);
 }
 
-static void update_bg_color(void)
-{
-	gdk_rgb_find_color(gtk_widget_get_colormap(GTK_WIDGET(mainwin)), bg_color);
-	gdk_gc_set_rgb_bg_color(gc, bg_color);
-	gdk_gc_set_rgb_fg_color(backgc, bg_color);
+static void update_bg_color(void) {
+  gdk_rgb_find_color(gtk_widget_get_colormap(GTK_WIDGET(mainwin)), bg_color);
+  gdk_gc_set_rgb_bg_color(gc, bg_color);
+  gdk_gc_set_rgb_fg_color(backgc, bg_color);
 
-	gdk_window_invalidate_rect(gtk_widget_get_window(mainwin), NULL, FALSE);
+  gdk_window_invalidate_rect(gtk_widget_get_window(mainwin), NULL, FALSE);
 }
 
 G_MODULE_EXPORT gboolean
 on_mainwin_button_press_event(GtkWidget *widget, GdkEventButton *event,
-		G_GNUC_UNUSED gpointer user_data)
-{
-	GObject *popup;
+                              G_GNUC_UNUSED gpointer user_data) {
+  GObject *popup;
 
-	switch (event->button) {
-	case 1:
-		if (current_test->cycle != NULL) {
-			current_test->cycle(widget);
-			gdk_window_invalidate_rect(gtk_widget_get_window(mainwin), NULL, FALSE);
-		}
-		break;
-	case 2:
-		if (++fg_count >= COLOR_MAX)
-			fg_count = COLOR_WHITE;
-		gdk_color_free(fg_color);
-		fg_color = gdk_color_copy(&fgcolors[fg_count]);
-		update_fg_color();
-		break;
-	case 3:
-		popup = gtk_builder_get_object(builder, "popup");
-		gtk_menu_popup(GTK_MENU(popup), NULL, NULL, NULL, NULL,
-			       event->button, event->time);
-		break;
-	}
-	return TRUE;
+  switch (event->button) {
+  case 1:
+    if (current_test->cycle != NULL) {
+      current_test->cycle(widget);
+      gdk_window_invalidate_rect(gtk_widget_get_window(mainwin), NULL, FALSE);
+    }
+    break;
+  case 2:
+    if (++fg_count >= COLOR_MAX)
+      fg_count = COLOR_WHITE;
+    gdk_color_free(fg_color);
+    fg_color = gdk_color_copy(&fgcolors[fg_count]);
+    update_fg_color();
+    break;
+  case 3:
+    popup = gtk_builder_get_object(builder, "popup");
+    gtk_menu_popup(GTK_MENU(popup), NULL, NULL, NULL, NULL, event->button,
+                   event->time);
+    break;
+  }
+  return TRUE;
 }
 
 /*
  * FIXME: GTK_WINDOW_POPUP does not seem to be able to receive
  * KeyPress events. How to enable this?
  */
-G_MODULE_EXPORT gboolean
-on_mainwin_key_press_event(G_GNUC_UNUSED GtkWidget *widget,
-		G_GNUC_UNUSED GdkEventKey *event,
-		G_GNUC_UNUSED gpointer user_data)
-{
-	gtk_main_quit();
-	return FALSE;
+G_MODULE_EXPORT gboolean on_mainwin_key_press_event(
+    G_GNUC_UNUSED GtkWidget *widget, G_GNUC_UNUSED GdkEventKey *event,
+    G_GNUC_UNUSED gpointer user_data) {
+  gtk_main_quit();
+  return FALSE;
 }
 
 G_MODULE_EXPORT gboolean
 on_mainwin_expose_event(GtkWidget *widget, G_GNUC_UNUSED GdkEventExpose *event,
-		G_GNUC_UNUSED gpointer user_data)
-{
-	gdk_window_set_background(gtk_widget_get_window(widget), bg_color);
-	gdk_window_clear(gtk_widget_get_window(widget));
+                        G_GNUC_UNUSED gpointer user_data) {
+  gdk_window_set_background(gtk_widget_get_window(widget), bg_color);
+  gdk_window_clear(gtk_widget_get_window(widget));
 
-	if (current_test && current_test->draw)
-		current_test->draw(widget);
-	return TRUE;
+  if (current_test && current_test->draw)
+    current_test->draw(widget);
+  return TRUE;
 }
 
-G_MODULE_EXPORT void
-on_mode_change(GtkMenuItem *menuitem, G_GNUC_UNUSED gpointer user_data)
-{
-	GtkCheckMenuItem *checkmenuitem = GTK_CHECK_MENU_ITEM(menuitem);
+G_MODULE_EXPORT void on_mode_change(GtkMenuItem *menuitem,
+                                    G_GNUC_UNUSED gpointer user_data) {
+  GtkCheckMenuItem *checkmenuitem = GTK_CHECK_MENU_ITEM(menuitem);
 
-	if (!gtk_check_menu_item_get_active(checkmenuitem)) {
-		if (current_test->close != NULL) {
-			current_test->close(mainwin);
-			current_test = NULL;
-		}
-	} else {
-		const char *test_name = gtk_buildable_get_name(GTK_BUILDABLE(menuitem));
-		g_assert(test_name != NULL);
-		GModule *exe = g_module_open(NULL, 0);
-		g_assert(exe != NULL);
-		gchar *test_struct = g_strconcat(test_name, "_ops", NULL);
-		if (g_module_symbol(exe, test_struct, (gpointer) &current_test) != TRUE) {
-			GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(mainwin),
-				GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-				GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE,
-				_("No implementation for the test \"%s\" found."),
-				test_name);
-			gtk_window_set_title(GTK_WINDOW(dialog), PACKAGE_NAME);
-			gtk_dialog_run(GTK_DIALOG(dialog));
-			gtk_main_quit();
-		}
-		free(test_struct);
-		g_module_close(exe);
-		if (current_test != NULL && current_test->init != NULL) {
-			current_test->init(mainwin);
-		}
-		on_mainwin_expose_event(mainwin, NULL, NULL);
-	}
+  if (!gtk_check_menu_item_get_active(checkmenuitem)) {
+    if (current_test->close != NULL) {
+      current_test->close(mainwin);
+      current_test = NULL;
+    }
+  } else {
+    const char *test_name = gtk_buildable_get_name(GTK_BUILDABLE(menuitem));
+    g_assert(test_name != NULL);
+    GModule *exe = g_module_open(NULL, 0);
+    g_assert(exe != NULL);
+    gchar *test_struct = g_strconcat(test_name, "_ops", NULL);
+    if (g_module_symbol(exe, test_struct, (gpointer)&current_test) != TRUE) {
+      GtkWidget *dialog = gtk_message_dialog_new(
+          GTK_WINDOW(mainwin),
+          GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_ERROR,
+          GTK_BUTTONS_CLOSE, _("No implementation for the test \"%s\" found."),
+          test_name);
+      gtk_window_set_title(GTK_WINDOW(dialog), PACKAGE_NAME);
+      gtk_dialog_run(GTK_DIALOG(dialog));
+      gtk_main_quit();
+    }
+    free(test_struct);
+    g_module_close(exe);
+    if (current_test != NULL && current_test->init != NULL) {
+      current_test->init(mainwin);
+    }
+    on_mainwin_expose_event(mainwin, NULL, NULL);
+  }
 }
 
-G_MODULE_EXPORT void
-on_fg_color_activate(G_GNUC_UNUSED GtkMenuItem *menuitem,
-		G_GNUC_UNUSED gpointer user_data)
-{
-	GtkColorSelection *colorsel;
-	GObject *fg_color_selector;
+G_MODULE_EXPORT void on_fg_color_activate(G_GNUC_UNUSED GtkMenuItem *menuitem,
+                                          G_GNUC_UNUSED gpointer user_data) {
+  GtkColorSelection *colorsel;
+  GObject *fg_color_selector;
 
-	fg_color_selector = gtk_builder_get_object(builder, "fg_color_selector");
+  fg_color_selector = gtk_builder_get_object(builder, "fg_color_selector");
 
-	colorsel = GTK_COLOR_SELECTION(gtk_color_selection_dialog_get_color_selection(GTK_COLOR_SELECTION_DIALOG(fg_color_selector)));
-	gtk_color_selection_set_current_color(colorsel, fg_color);
-	switch (gtk_dialog_run(GTK_DIALOG(fg_color_selector))) {
-		case GTK_RESPONSE_OK:
-			gtk_color_selection_get_current_color(colorsel,
-					fg_color);
-			update_fg_color();
-			break;
-		case GTK_RESPONSE_CANCEL:
-		case GTK_RESPONSE_DELETE_EVENT:
-			break;
-		default:
-			g_assert_not_reached();
-	}
-	gtk_widget_hide(GTK_WIDGET(fg_color_selector));
+  colorsel = GTK_COLOR_SELECTION(gtk_color_selection_dialog_get_color_selection(
+      GTK_COLOR_SELECTION_DIALOG(fg_color_selector)));
+  gtk_color_selection_set_current_color(colorsel, fg_color);
+  switch (gtk_dialog_run(GTK_DIALOG(fg_color_selector))) {
+  case GTK_RESPONSE_OK:
+    gtk_color_selection_get_current_color(colorsel, fg_color);
+    update_fg_color();
+    break;
+  case GTK_RESPONSE_CANCEL:
+  case GTK_RESPONSE_DELETE_EVENT:
+    break;
+  default:
+    g_assert_not_reached();
+  }
+  gtk_widget_hide(GTK_WIDGET(fg_color_selector));
 }
 
-G_MODULE_EXPORT void
-on_bg_color_activate(G_GNUC_UNUSED GtkMenuItem *menuitem,
-		G_GNUC_UNUSED gpointer user_data)
-{
-	GtkColorSelection *colorsel;
-	GObject *bg_color_selector;
+G_MODULE_EXPORT void on_bg_color_activate(G_GNUC_UNUSED GtkMenuItem *menuitem,
+                                          G_GNUC_UNUSED gpointer user_data) {
+  GtkColorSelection *colorsel;
+  GObject *bg_color_selector;
 
-	bg_color_selector = gtk_builder_get_object(builder, "bg_color_selector");
+  bg_color_selector = gtk_builder_get_object(builder, "bg_color_selector");
 
-	colorsel = GTK_COLOR_SELECTION(gtk_color_selection_dialog_get_color_selection(GTK_COLOR_SELECTION_DIALOG(bg_color_selector)));
-	gtk_color_selection_set_current_color(colorsel, bg_color);
-	switch (gtk_dialog_run(GTK_DIALOG(bg_color_selector))) {
-		case GTK_RESPONSE_OK:
-			gtk_color_selection_get_current_color(colorsel,
-					bg_color);
-			update_bg_color();
-			break;
-		case GTK_RESPONSE_CANCEL:
-		case GTK_RESPONSE_DELETE_EVENT:
-			break;
-		default:
-			g_assert_not_reached();
-	}
-	gtk_widget_hide(GTK_WIDGET(bg_color_selector));
+  colorsel = GTK_COLOR_SELECTION(gtk_color_selection_dialog_get_color_selection(
+      GTK_COLOR_SELECTION_DIALOG(bg_color_selector)));
+  gtk_color_selection_set_current_color(colorsel, bg_color);
+  switch (gtk_dialog_run(GTK_DIALOG(bg_color_selector))) {
+  case GTK_RESPONSE_OK:
+    gtk_color_selection_get_current_color(colorsel, bg_color);
+    update_bg_color();
+    break;
+  case GTK_RESPONSE_CANCEL:
+  case GTK_RESPONSE_DELETE_EVENT:
+    break;
+  default:
+    g_assert_not_reached();
+  }
+  gtk_widget_hide(GTK_WIDGET(bg_color_selector));
 }
-

--- a/callbacks.h
+++ b/callbacks.h
@@ -21,24 +21,24 @@
 #include <gtk/gtk.h>
 
 struct test_ops {
-	void (*init) (GtkWidget * widget);
-	void (*draw) (GtkWidget * widget);
-	void (*cycle) (GtkWidget * widget);
-	void (*close) (GtkWidget * widget);
+  void (*init)(GtkWidget *widget);
+  void (*draw)(GtkWidget *widget);
+  void (*cycle)(GtkWidget *widget);
+  void (*close)(GtkWidget *widget);
 };
 
 extern struct test_ops basic_ops;
 
 enum test_color {
-	COLOR_WHITE,
-	COLOR_RED,
-	COLOR_GREEN,
-	COLOR_BLUE,
-	COLOR_CYAN,
-	COLOR_MAGENTA,
-	COLOR_YELLOW,
-	COLOR_BLACK,
-	COLOR_MAX
+  COLOR_WHITE,
+  COLOR_RED,
+  COLOR_GREEN,
+  COLOR_BLUE,
+  COLOR_CYAN,
+  COLOR_MAGENTA,
+  COLOR_YELLOW,
+  COLOR_BLACK,
+  COLOR_MAX
 };
 
 #define GRAYS_MAX COLOR_MAX

--- a/gettext.h
+++ b/gettext.h
@@ -1,5 +1,6 @@
 /* Convenience header for conditional use of GNU <libintl.h>.
-   Copyright (C) 1995-1998, 2000-2002, 2004-2006, 2009-2011 Free Software Foundation, Inc.
+   Copyright (C) 1995-1998, 2000-2002, 2004-2006, 2009-2011 Free Software
+   Foundation, Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -21,19 +22,18 @@
 #if ENABLE_NLS
 
 /* Get declarations of GNU message catalog functions.  */
-# include <libintl.h>
+#include <libintl.h>
 
 /* You can set the DEFAULT_TEXT_DOMAIN macro to specify the domain used by
    the gettext() and ngettext() macros.  This is an alternative to calling
    textdomain(), and is useful for libraries.  */
-# ifdef DEFAULT_TEXT_DOMAIN
-#  undef gettext
-#  define gettext(Msgid) \
-     dgettext (DEFAULT_TEXT_DOMAIN, Msgid)
-#  undef ngettext
-#  define ngettext(Msgid1, Msgid2, N) \
-     dngettext (DEFAULT_TEXT_DOMAIN, Msgid1, Msgid2, N)
-# endif
+#ifdef DEFAULT_TEXT_DOMAIN
+#undef gettext
+#define gettext(Msgid) dgettext(DEFAULT_TEXT_DOMAIN, Msgid)
+#undef ngettext
+#define ngettext(Msgid1, Msgid2, N)                                            \
+  dngettext(DEFAULT_TEXT_DOMAIN, Msgid1, Msgid2, N)
+#endif
 
 #else
 
@@ -44,17 +44,17 @@
    and also including <libintl.h> would fail on SunOS 4, whereas <locale.h>
    is OK.  */
 #if defined(__sun)
-# include <locale.h>
+#include <locale.h>
 #endif
 
 /* Many header files from the libstdc++ coming with g++ 3.3 or newer include
    <libintl.h>, which chokes if dcgettext is defined as a macro.  So include
    it now, to make later inclusions of <libintl.h> a NOP.  */
 #if defined(__cplusplus) && defined(__GNUG__) && (__GNUC__ >= 3)
-# include <cstdlib>
-# if (__GLIBC__ >= 2 && !defined __UCLIBC__) || _GLIBCXX_HAVE_LIBINTL_H
-#  include <libintl.h>
-# endif
+#include <cstdlib>
+#if (__GLIBC__ >= 2 && !defined __UCLIBC__) || _GLIBCXX_HAVE_LIBINTL_H
+#include <libintl.h>
+#endif
 #endif
 
 /* Disabled NLS.
@@ -62,39 +62,38 @@
    for invalid uses of the value returned from these functions.
    On pre-ANSI systems without 'const', the config.h file is supposed to
    contain "#define const".  */
-# undef gettext
-# define gettext(Msgid) ((const char *) (Msgid))
-# undef dgettext
-# define dgettext(Domainname, Msgid) ((void) (Domainname), gettext (Msgid))
-# undef dcgettext
-# define dcgettext(Domainname, Msgid, Category) \
-    ((void) (Category), dgettext (Domainname, Msgid))
-# undef ngettext
-# define ngettext(Msgid1, Msgid2, N) \
-    ((N) == 1 \
-     ? ((void) (Msgid2), (const char *) (Msgid1)) \
-     : ((void) (Msgid1), (const char *) (Msgid2)))
-# undef dngettext
-# define dngettext(Domainname, Msgid1, Msgid2, N) \
-    ((void) (Domainname), ngettext (Msgid1, Msgid2, N))
-# undef dcngettext
-# define dcngettext(Domainname, Msgid1, Msgid2, N, Category) \
-    ((void) (Category), dngettext (Domainname, Msgid1, Msgid2, N))
-# undef textdomain
-# define textdomain(Domainname) ((const char *) (Domainname))
-# undef bindtextdomain
-# define bindtextdomain(Domainname, Dirname) \
-    ((void) (Domainname), (const char *) (Dirname))
-# undef bind_textdomain_codeset
-# define bind_textdomain_codeset(Domainname, Codeset) \
-    ((void) (Domainname), (const char *) (Codeset))
+#undef gettext
+#define gettext(Msgid) ((const char *)(Msgid))
+#undef dgettext
+#define dgettext(Domainname, Msgid) ((void)(Domainname), gettext(Msgid))
+#undef dcgettext
+#define dcgettext(Domainname, Msgid, Category)                                 \
+  ((void)(Category), dgettext(Domainname, Msgid))
+#undef ngettext
+#define ngettext(Msgid1, Msgid2, N)                                            \
+  ((N) == 1 ? ((void)(Msgid2), (const char *)(Msgid1))                         \
+            : ((void)(Msgid1), (const char *)(Msgid2)))
+#undef dngettext
+#define dngettext(Domainname, Msgid1, Msgid2, N)                               \
+  ((void)(Domainname), ngettext(Msgid1, Msgid2, N))
+#undef dcngettext
+#define dcngettext(Domainname, Msgid1, Msgid2, N, Category)                    \
+  ((void)(Category), dngettext(Domainname, Msgid1, Msgid2, N))
+#undef textdomain
+#define textdomain(Domainname) ((const char *)(Domainname))
+#undef bindtextdomain
+#define bindtextdomain(Domainname, Dirname)                                    \
+  ((void)(Domainname), (const char *)(Dirname))
+#undef bind_textdomain_codeset
+#define bind_textdomain_codeset(Domainname, Codeset)                           \
+  ((void)(Domainname), (const char *)(Codeset))
 
 #endif
 
 /* Prefer gnulib's setlocale override over libintl's setlocale override.  */
 #ifdef GNULIB_defined_setlocale
-# undef setlocale
-# define setlocale rpl_setlocale
+#undef setlocale
+#define setlocale rpl_setlocale
 #endif
 
 /* A pseudo function call that serves as a marker for the automated
@@ -114,27 +113,33 @@
    short and rarely need to change.
    The letter 'p' stands for 'particular' or 'special'.  */
 #ifdef DEFAULT_TEXT_DOMAIN
-# define pgettext(Msgctxt, Msgid) \
-   pgettext_aux (DEFAULT_TEXT_DOMAIN, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, LC_MESSAGES)
+#define pgettext(Msgctxt, Msgid)                                               \
+  pgettext_aux(DEFAULT_TEXT_DOMAIN, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, \
+               LC_MESSAGES)
 #else
-# define pgettext(Msgctxt, Msgid) \
-   pgettext_aux (NULL, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, LC_MESSAGES)
+#define pgettext(Msgctxt, Msgid)                                               \
+  pgettext_aux(NULL, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, LC_MESSAGES)
 #endif
-#define dpgettext(Domainname, Msgctxt, Msgid) \
-  pgettext_aux (Domainname, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, LC_MESSAGES)
-#define dcpgettext(Domainname, Msgctxt, Msgid, Category) \
-  pgettext_aux (Domainname, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, Category)
+#define dpgettext(Domainname, Msgctxt, Msgid)                                  \
+  pgettext_aux(Domainname, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid,          \
+               LC_MESSAGES)
+#define dcpgettext(Domainname, Msgctxt, Msgid, Category)                       \
+  pgettext_aux(Domainname, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, Category)
 #ifdef DEFAULT_TEXT_DOMAIN
-# define npgettext(Msgctxt, Msgid, MsgidPlural, N) \
-   npgettext_aux (DEFAULT_TEXT_DOMAIN, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, MsgidPlural, N, LC_MESSAGES)
+#define npgettext(Msgctxt, Msgid, MsgidPlural, N)                              \
+  npgettext_aux(DEFAULT_TEXT_DOMAIN, Msgctxt GETTEXT_CONTEXT_GLUE Msgid,       \
+                Msgid, MsgidPlural, N, LC_MESSAGES)
 #else
-# define npgettext(Msgctxt, Msgid, MsgidPlural, N) \
-   npgettext_aux (NULL, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, MsgidPlural, N, LC_MESSAGES)
+#define npgettext(Msgctxt, Msgid, MsgidPlural, N)                              \
+  npgettext_aux(NULL, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, MsgidPlural,  \
+                N, LC_MESSAGES)
 #endif
-#define dnpgettext(Domainname, Msgctxt, Msgid, MsgidPlural, N) \
-  npgettext_aux (Domainname, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, MsgidPlural, N, LC_MESSAGES)
-#define dcnpgettext(Domainname, Msgctxt, Msgid, MsgidPlural, N, Category) \
-  npgettext_aux (Domainname, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, MsgidPlural, N, Category)
+#define dnpgettext(Domainname, Msgctxt, Msgid, MsgidPlural, N)                 \
+  npgettext_aux(Domainname, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid,         \
+                MsgidPlural, N, LC_MESSAGES)
+#define dcnpgettext(Domainname, Msgctxt, Msgid, MsgidPlural, N, Category)      \
+  npgettext_aux(Domainname, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid,         \
+                MsgidPlural, N, Category)
 
 #ifdef __GNUC__
 __inline
@@ -143,12 +148,10 @@ __inline
 inline
 #endif
 #endif
-static const char *
-pgettext_aux (const char *domain,
-              const char *msg_ctxt_id, const char *msgid,
-              int category)
-{
-  const char *translation = dcgettext (domain, msg_ctxt_id, category);
+    static const char *
+    pgettext_aux(const char *domain, const char *msg_ctxt_id, const char *msgid,
+                 int category) {
+  const char *translation = dcgettext(domain, msg_ctxt_id, category);
   if (translation == msg_ctxt_id)
     return msgid;
   else
@@ -162,14 +165,12 @@ __inline
 inline
 #endif
 #endif
-static const char *
-npgettext_aux (const char *domain,
-               const char *msg_ctxt_id, const char *msgid,
-               const char *msgid_plural, unsigned long int n,
-               int category)
-{
+    static const char *
+    npgettext_aux(const char *domain, const char *msg_ctxt_id,
+                  const char *msgid, const char *msgid_plural,
+                  unsigned long int n, int category) {
   const char *translation =
-    dcngettext (domain, msg_ctxt_id, msgid_plural, n, category);
+      dcngettext(domain, msg_ctxt_id, msgid_plural, n, category);
   if (translation == msg_ctxt_id || translation == msgid_plural)
     return (n == 1 ? msgid : msgid_plural);
   else
@@ -182,21 +183,21 @@ npgettext_aux (const char *domain,
 
 #include <string.h>
 
-#if (((__GNUC__ >= 3 || __GNUG__ >= 2) && !defined __STRICT_ANSI__) \
-     /* || __STDC_VERSION__ >= 199901L */ )
-# define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 1
+#if (((__GNUC__ >= 3 || __GNUG__ >= 2) &&                                      \
+      !defined __STRICT_ANSI__) /* || __STDC_VERSION__ >= 199901L */)
+#define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 1
 #else
-# define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 0
+#define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 0
 #endif
 
 #if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
 #include <stdlib.h>
 #endif
 
-#define pgettext_expr(Msgctxt, Msgid) \
-  dcpgettext_expr (NULL, Msgctxt, Msgid, LC_MESSAGES)
-#define dpgettext_expr(Domainname, Msgctxt, Msgid) \
-  dcpgettext_expr (Domainname, Msgctxt, Msgid, LC_MESSAGES)
+#define pgettext_expr(Msgctxt, Msgid)                                          \
+  dcpgettext_expr(NULL, Msgctxt, Msgid, LC_MESSAGES)
+#define dpgettext_expr(Domainname, Msgctxt, Msgid)                             \
+  dcpgettext_expr(Domainname, Msgctxt, Msgid, LC_MESSAGES)
 
 #ifdef __GNUC__
 __inline
@@ -205,43 +206,40 @@ __inline
 inline
 #endif
 #endif
-static const char *
-dcpgettext_expr (const char *domain,
-                 const char *msgctxt, const char *msgid,
-                 int category)
-{
-  size_t msgctxt_len = strlen (msgctxt) + 1;
-  size_t msgid_len = strlen (msgid) + 1;
+    static const char *
+    dcpgettext_expr(const char *domain, const char *msgctxt, const char *msgid,
+                    int category) {
+  size_t msgctxt_len = strlen(msgctxt) + 1;
+  size_t msgid_len = strlen(msgid) + 1;
   const char *translation;
 #if _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
   char msg_ctxt_id[msgctxt_len + msgid_len];
 #else
   char buf[1024];
-  char *msg_ctxt_id =
-    (msgctxt_len + msgid_len <= sizeof (buf)
-     ? buf
-     : (char *) malloc (msgctxt_len + msgid_len));
+  char *msg_ctxt_id = (msgctxt_len + msgid_len <= sizeof(buf)
+                           ? buf
+                           : (char *)malloc(msgctxt_len + msgid_len));
   if (msg_ctxt_id != NULL)
 #endif
-    {
-      memcpy (msg_ctxt_id, msgctxt, msgctxt_len - 1);
-      msg_ctxt_id[msgctxt_len - 1] = '\004';
-      memcpy (msg_ctxt_id + msgctxt_len, msgid, msgid_len);
-      translation = dcgettext (domain, msg_ctxt_id, category);
+  {
+    memcpy(msg_ctxt_id, msgctxt, msgctxt_len - 1);
+    msg_ctxt_id[msgctxt_len - 1] = '\004';
+    memcpy(msg_ctxt_id + msgctxt_len, msgid, msgid_len);
+    translation = dcgettext(domain, msg_ctxt_id, category);
 #if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
-      if (msg_ctxt_id != buf)
-        free (msg_ctxt_id);
+    if (msg_ctxt_id != buf)
+      free(msg_ctxt_id);
 #endif
-      if (translation != msg_ctxt_id)
-        return translation;
-    }
+    if (translation != msg_ctxt_id)
+      return translation;
+  }
   return msgid;
 }
 
-#define npgettext_expr(Msgctxt, Msgid, MsgidPlural, N) \
-  dcnpgettext_expr (NULL, Msgctxt, Msgid, MsgidPlural, N, LC_MESSAGES)
-#define dnpgettext_expr(Domainname, Msgctxt, Msgid, MsgidPlural, N) \
-  dcnpgettext_expr (Domainname, Msgctxt, Msgid, MsgidPlural, N, LC_MESSAGES)
+#define npgettext_expr(Msgctxt, Msgid, MsgidPlural, N)                         \
+  dcnpgettext_expr(NULL, Msgctxt, Msgid, MsgidPlural, N, LC_MESSAGES)
+#define dnpgettext_expr(Domainname, Msgctxt, Msgid, MsgidPlural, N)            \
+  dcnpgettext_expr(Domainname, Msgctxt, Msgid, MsgidPlural, N, LC_MESSAGES)
 
 #ifdef __GNUC__
 __inline
@@ -250,37 +248,34 @@ __inline
 inline
 #endif
 #endif
-static const char *
-dcnpgettext_expr (const char *domain,
-                  const char *msgctxt, const char *msgid,
-                  const char *msgid_plural, unsigned long int n,
-                  int category)
-{
-  size_t msgctxt_len = strlen (msgctxt) + 1;
-  size_t msgid_len = strlen (msgid) + 1;
+    static const char *
+    dcnpgettext_expr(const char *domain, const char *msgctxt, const char *msgid,
+                     const char *msgid_plural, unsigned long int n,
+                     int category) {
+  size_t msgctxt_len = strlen(msgctxt) + 1;
+  size_t msgid_len = strlen(msgid) + 1;
   const char *translation;
 #if _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
   char msg_ctxt_id[msgctxt_len + msgid_len];
 #else
   char buf[1024];
-  char *msg_ctxt_id =
-    (msgctxt_len + msgid_len <= sizeof (buf)
-     ? buf
-     : (char *) malloc (msgctxt_len + msgid_len));
+  char *msg_ctxt_id = (msgctxt_len + msgid_len <= sizeof(buf)
+                           ? buf
+                           : (char *)malloc(msgctxt_len + msgid_len));
   if (msg_ctxt_id != NULL)
 #endif
-    {
-      memcpy (msg_ctxt_id, msgctxt, msgctxt_len - 1);
-      msg_ctxt_id[msgctxt_len - 1] = '\004';
-      memcpy (msg_ctxt_id + msgctxt_len, msgid, msgid_len);
-      translation = dcngettext (domain, msg_ctxt_id, msgid_plural, n, category);
+  {
+    memcpy(msg_ctxt_id, msgctxt, msgctxt_len - 1);
+    msg_ctxt_id[msgctxt_len - 1] = '\004';
+    memcpy(msg_ctxt_id + msgctxt_len, msgid, msgid_len);
+    translation = dcngettext(domain, msg_ctxt_id, msgid_plural, n, category);
 #if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
-      if (msg_ctxt_id != buf)
-        free (msg_ctxt_id);
+    if (msg_ctxt_id != buf)
+      free(msg_ctxt_id);
 #endif
-      if (!(translation == msg_ctxt_id || translation == msgid_plural))
-        return translation;
-    }
+    if (!(translation == msg_ctxt_id || translation == msgid_plural))
+      return translation;
+  }
   return (n == 1 ? msgid : msgid_plural);
 }
 

--- a/main.c
+++ b/main.c
@@ -20,43 +20,43 @@
 
 #include <config.h>
 
-#include <stdlib.h>
 #include <gtk/gtk.h>
+#include <stdlib.h>
 
-#include "main.h"
 #include "gettext.h"
+#include "main.h"
 #define _(String) gettext(String)
 
 GtkBuilder *builder;
 
-int main(int argc, char *argv[])
-{
-	guint err;
+int main(int argc, char *argv[]) {
+  guint err;
 
-	bindtextdomain(PACKAGE, LOCALEDIR);
-	bind_textdomain_codeset(PACKAGE, "UTF-8");
-	textdomain(PACKAGE);
+  bindtextdomain(PACKAGE, LOCALEDIR);
+  bind_textdomain_codeset(PACKAGE, "UTF-8");
+  textdomain(PACKAGE);
 
-	gtk_init(&argc, &argv);
+  gtk_init(&argc, &argv);
 
-	builder = gtk_builder_new();
-	err = gtk_builder_add_from_file(builder, DATADIR "/screentest/screentest.ui", NULL);
-	if (err == 0)
-		err = gtk_builder_add_from_file(builder, "screentest.ui", NULL);
-	if (err == 0) {
-		GtkWidget *dialog = gtk_message_dialog_new(NULL,
-			GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-			GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE,
-			_("The interface definition file was not found.\n"
-			"Please make sure this program is installed correctly."));
-		gtk_window_set_title(GTK_WINDOW(dialog), PACKAGE_NAME);
-		gtk_dialog_run(GTK_DIALOG(dialog));
-		exit(1);
-	}
+  builder = gtk_builder_new();
+  err = gtk_builder_add_from_file(builder, DATADIR "/screentest/screentest.ui",
+                                  NULL);
+  if (err == 0)
+    err = gtk_builder_add_from_file(builder, "screentest.ui", NULL);
+  if (err == 0) {
+    GtkWidget *dialog = gtk_message_dialog_new(
+        NULL, GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+        GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE,
+        _("The interface definition file was not found.\n"
+          "Please make sure this program is installed correctly."));
+    gtk_window_set_title(GTK_WINDOW(dialog), PACKAGE_NAME);
+    gtk_dialog_run(GTK_DIALOG(dialog));
+    exit(1);
+  }
 
-	gtk_builder_connect_signals(builder, NULL);
+  gtk_builder_connect_signals(builder, NULL);
 
-	gtk_widget_show_all(GTK_WIDGET(gtk_builder_get_object(builder, "mainwin")));
-	gtk_main();
-	return 0;
+  gtk_widget_show_all(GTK_WIDGET(gtk_builder_get_object(builder, "mainwin")));
+  gtk_main();
+  return 0;
 }

--- a/test_basic.c
+++ b/test_basic.c
@@ -21,8 +21,8 @@
 
 #include <config.h>
 
-#include <stdio.h>
 #include <gtk/gtk.h>
+#include <stdio.h>
 
 #include "callbacks.h"
 #include "gettext.h"
@@ -35,126 +35,117 @@ static gchar fontname[] =
     "-adobe-helvetica-bold-r-normal-*-14-*-*-*-p-*-iso8859-1";
 static GdkFont *font;
 
-static void basic_init(G_GNUC_UNUSED GtkWidget * widget)
-{
-	font = gdk_font_load(fontname);
+static void basic_init(G_GNUC_UNUSED GtkWidget *widget) {
+  font = gdk_font_load(fontname);
 
-	if (!font) {
-		printf("Cannot load font %s, trying 'fixed'.\n", fontname);
-		font = gdk_font_load("fixed");
-	}
+  if (!font) {
+    printf("Cannot load font %s, trying 'fixed'.\n", fontname);
+    font = gdk_font_load("fixed");
+  }
 }
 
-static void draw_boxes(GdkWindow * win, GdkColor * colors, gint ncols,
-		       gint x, gint y, gint d)
-{
-	int i;
+static void draw_boxes(GdkWindow *win, GdkColor *colors, gint ncols, gint x,
+                       gint y, gint d) {
+  int i;
 
-	for (i = 0; i < ncols; i++) {
-		gdk_gc_set_rgb_fg_color(gc, &colors[i]);
+  for (i = 0; i < ncols; i++) {
+    gdk_gc_set_rgb_fg_color(gc, &colors[i]);
 
-		gdk_draw_rectangle(win, gc, TRUE, x, y, d, d);
-		x += d;
-	}
+    gdk_draw_rectangle(win, gc, TRUE, x, y, d, d);
+    x += d;
+  }
 
-	gdk_gc_set_rgb_fg_color(gc, fg_color);
+  gdk_gc_set_rgb_fg_color(gc, fg_color);
 }
 
-static void basic_draw(GtkWidget * widget)
-{
-	GdkWindow *win = gtk_widget_get_window(widget);
-	gint w, h;
-	gint i, b, d;
-	gint maxwidth, maxheight;
-	gint widths[7];
-	static gchar *text[] = {
-		"Screentest v" VERSION,
-		"(C) 2001 Jan \"Yenya\" Kasprzak <kas@fi.muni.cz>",
-		"(C) 2006-2017 Tobias Gruetzmacher <tobias-screentest@23.gs>",
-		"(C) 2021 Apr Thorsten Kattanek <thorsten.kattanek@gmx.de>",
-		N_("Left Button - param cycle, if any"),
-		N_("Middle Button - color cycle"),
-		N_("Right Button - menu"),
-	};
+static void basic_draw(GtkWidget *widget) {
+  GdkWindow *win = gtk_widget_get_window(widget);
+  gint w, h;
+  gint i, b, d;
+  gint maxwidth, maxheight;
+  gint widths[7];
+  static gchar *text[] = {
+      "Screentest v" VERSION,
+      "(C) 2001 Jan \"Yenya\" Kasprzak <kas@fi.muni.cz>",
+      "(C) 2006-2017 Tobias Gruetzmacher <tobias-screentest@23.gs>",
+      "(C) 2021 Apr Thorsten Kattanek <thorsten.kattanek@gmx.de>",
+      N_("Left Button - param cycle, if any"),
+      N_("Middle Button - color cycle"),
+      N_("Right Button - menu"),
+  };
 
-	gdk_drawable_get_size(win, &w, &h);
+  gdk_drawable_get_size(win, &w, &h);
 
-	for (i = ((w - 1) % BASIC_STEP) / 2; i < w; i += BASIC_STEP)
-		gdk_draw_line(win, gc, i, 0, i, h - 1);
-	for (i = ((h - 1) % BASIC_STEP) / 2; i < h; i += BASIC_STEP)
-		gdk_draw_line(win, gc, 0, i, w - 1, i);
+  for (i = ((w - 1) % BASIC_STEP) / 2; i < w; i += BASIC_STEP)
+    gdk_draw_line(win, gc, i, 0, i, h - 1);
+  for (i = ((h - 1) % BASIC_STEP) / 2; i < h; i += BASIC_STEP)
+    gdk_draw_line(win, gc, 0, i, w - 1, i);
 
-	d = w / 4;
-	if (d > h / 4)
-		d = h / 4;
+  d = w / 4;
+  if (d > h / 4)
+    d = h / 4;
 
-	maxheight = 0;
-	for (i = 0; i < 7; i++) {
-		int x = gdk_string_height(font, gettext(text[i]));
-		if (x > maxheight)
-			maxheight = x;
-	}
+  maxheight = 0;
+  for (i = 0; i < 7; i++) {
+    int x = gdk_string_height(font, gettext(text[i]));
+    if (x > maxheight)
+      maxheight = x;
+  }
 
-	maxwidth = 0;
-	for (i = 0; i < 7; i++) {
-		widths[i] = gdk_string_width(font, gettext(text[i]));
-		if (widths[i] > maxwidth)
-			maxwidth = widths[i];
-	}
+  maxwidth = 0;
+  for (i = 0; i < 7; i++) {
+    widths[i] = gdk_string_width(font, gettext(text[i]));
+    if (widths[i] > maxwidth)
+      maxwidth = widths[i];
+  }
 
-	maxwidth += 20;
-	maxheight = 3 * maxheight / 2;
-	gdk_draw_rectangle(win, gc, FALSE, (w - maxwidth) / 2,
-                           d / 2 - 2 * maxheight, maxwidth, 5 * maxheight);
-	gdk_draw_rectangle(win, gc, FALSE, (w - maxwidth) / 2,
-			   h - d / 2 - 2 * maxheight, maxwidth,
-			   4 * maxheight);
-	gdk_draw_rectangle(win, backgc, TRUE, (w - maxwidth) / 2 + 1,
-			   d / 2 - 2 * maxheight + 1, maxwidth - 1,
-			   5 * maxheight - 1);
-	gdk_draw_rectangle(win, backgc, TRUE, (w - maxwidth) / 2 + 1,
-			   h - d / 2 - 2 * maxheight + 1, maxwidth - 1,
-			   4 * maxheight - 1);
+  maxwidth += 20;
+  maxheight = 3 * maxheight / 2;
+  gdk_draw_rectangle(win, gc, FALSE, (w - maxwidth) / 2, d / 2 - 2 * maxheight,
+                     maxwidth, 5 * maxheight);
+  gdk_draw_rectangle(win, gc, FALSE, (w - maxwidth) / 2,
+                     h - d / 2 - 2 * maxheight, maxwidth, 4 * maxheight);
+  gdk_draw_rectangle(win, backgc, TRUE, (w - maxwidth) / 2 + 1,
+                     d / 2 - 2 * maxheight + 1, maxwidth - 1,
+                     5 * maxheight - 1);
+  gdk_draw_rectangle(win, backgc, TRUE, (w - maxwidth) / 2 + 1,
+                     h - d / 2 - 2 * maxheight + 1, maxwidth - 1,
+                     4 * maxheight - 1);
 
-	gdk_draw_string(win, font, gc, (w - widths[0]) / 2,
-			d / 2 - 2 * maxheight / 3, gettext(text[0]));
-	gdk_draw_string(win, font, gc, (w - widths[1]) / 2,
-			d / 2 + maxheight / 3, gettext(text[1]));
-	gdk_draw_string(win, font, gc, (w - widths[2]) / 2,
-			d / 2 + 4 * maxheight / 3, gettext(text[2]));
-	gdk_draw_string(win, font, gc, (w - widths[3]) / 2,
-			d / 2 + 7 * maxheight / 3, gettext(text[3]));
+  gdk_draw_string(win, font, gc, (w - widths[0]) / 2, d / 2 - 2 * maxheight / 3,
+                  gettext(text[0]));
+  gdk_draw_string(win, font, gc, (w - widths[1]) / 2, d / 2 + maxheight / 3,
+                  gettext(text[1]));
+  gdk_draw_string(win, font, gc, (w - widths[2]) / 2, d / 2 + 4 * maxheight / 3,
+                  gettext(text[2]));
+  gdk_draw_string(win, font, gc, (w - widths[3]) / 2, d / 2 + 7 * maxheight / 3,
+                  gettext(text[3]));
 
-	gdk_draw_string(win, font, gc, (w - widths[4]) / 2,
-			h - d / 2 - 2 * maxheight / 3, gettext(text[4]));
-	gdk_draw_string(win, font, gc, (w - widths[5]) / 2,
-			h - d / 2 + maxheight / 3, gettext(text[5]));
-	gdk_draw_string(win, font, gc, (w - widths[6]) / 2,
-			h - d / 2 + 4 * maxheight / 3, gettext(text[6]));
+  gdk_draw_string(win, font, gc, (w - widths[4]) / 2,
+                  h - d / 2 - 2 * maxheight / 3, gettext(text[4]));
+  gdk_draw_string(win, font, gc, (w - widths[5]) / 2, h - d / 2 + maxheight / 3,
+                  gettext(text[5]));
+  gdk_draw_string(win, font, gc, (w - widths[6]) / 2,
+                  h - d / 2 + 4 * maxheight / 3, gettext(text[6]));
 
-	b = 7 * d / 4;
-	draw_boxes(win, fgcolors, COLOR_MAX, (w - b) / 2,
-		   h / 2 - b / COLOR_MAX, b / COLOR_MAX);
-	draw_boxes(win, grays, GRAYS_MAX, (w - b) / 2, h / 2,
-		   b / GRAYS_MAX);
-	w--;
-	h--;
-	gdk_draw_arc(win, gc, FALSE, 0, 0, d, d, 0, 360 * 64);
-	gdk_draw_arc(win, gc, FALSE, 0, h - d, d, d, 0, 360 * 64);
-	gdk_draw_arc(win, gc, FALSE, w - d, h - d, d, d, 0, 360 * 64);
-	gdk_draw_arc(win, gc, FALSE, w - d, 0, d, d, 0, 360 * 64);
-	gdk_draw_arc(win, gc, FALSE, w / 2 - d, h / 2 - d, d * 2, d * 2, 0,
-		     360 * 64);
+  b = 7 * d / 4;
+  draw_boxes(win, fgcolors, COLOR_MAX, (w - b) / 2, h / 2 - b / COLOR_MAX,
+             b / COLOR_MAX);
+  draw_boxes(win, grays, GRAYS_MAX, (w - b) / 2, h / 2, b / GRAYS_MAX);
+  w--;
+  h--;
+  gdk_draw_arc(win, gc, FALSE, 0, 0, d, d, 0, 360 * 64);
+  gdk_draw_arc(win, gc, FALSE, 0, h - d, d, d, 0, 360 * 64);
+  gdk_draw_arc(win, gc, FALSE, w - d, h - d, d, d, 0, 360 * 64);
+  gdk_draw_arc(win, gc, FALSE, w - d, 0, d, d, 0, 360 * 64);
+  gdk_draw_arc(win, gc, FALSE, w / 2 - d, h / 2 - d, d * 2, d * 2, 0, 360 * 64);
 }
 
-static void basic_close(G_GNUC_UNUSED GtkWidget * widget)
-{
-	gdk_font_unref(font);
+static void basic_close(G_GNUC_UNUSED GtkWidget *widget) {
+  gdk_font_unref(font);
 }
 
-G_MODULE_EXPORT struct test_ops basic_ops = {
-	.init = basic_init,
-	.draw = basic_draw,
-	.cycle = NULL,
-	.close = basic_close
-};
+G_MODULE_EXPORT struct test_ops basic_ops = {.init = basic_init,
+                                             .draw = basic_draw,
+                                             .cycle = NULL,
+                                             .close = basic_close};

--- a/test_blink.c
+++ b/test_blink.c
@@ -29,68 +29,53 @@ static guint timeout;
 static gint blink_type;
 static gint blink_step;
 
-static void blink_draw(GtkWidget * widget)
-{
-	GdkWindow *win = gtk_widget_get_window(widget);
-	gint w, h;
-	GdkGC *gc1, *gc2;
+static void blink_draw(GtkWidget *widget) {
+  GdkWindow *win = gtk_widget_get_window(widget);
+  gint w, h;
+  GdkGC *gc1, *gc2;
 
-	gdk_drawable_get_size(win, &w, &h);
+  gdk_drawable_get_size(win, &w, &h);
 
-	if (blink_step) {
-		gc1 = backgc;
-		gc2 = gc;
-	} else {
-		gc1 = gc;
-		gc2 = backgc;
-	}
+  if (blink_step) {
+    gc1 = backgc;
+    gc2 = gc;
+  } else {
+    gc1 = gc;
+    gc2 = backgc;
+  }
 
-	if (blink_type) {
-		gdk_draw_rectangle(win, gc1, TRUE, 5, 5, w / 3 - 5,
-				   h - 10);
-		gdk_draw_rectangle(win, gc2, TRUE, w / 3, 5, w / 3,
-				   h - 10);
-		gdk_draw_rectangle(win, gc1, TRUE, 2 * w / 3, 5, w / 3 - 5,
-				   h - 10);
-	} else {
-		gdk_draw_rectangle(win, gc1, TRUE, 5, 5, w - 10,
-				   h / 3 - 5);
-		gdk_draw_rectangle(win, gc2, TRUE, 5, h / 3, w - 10,
-				   h / 3);
-		gdk_draw_rectangle(win, gc1, TRUE, 5, 2 * h / 3, w - 10,
-				   h / 3 - 5);
-	}
-	gdk_draw_rectangle(win, gc, FALSE, 0, 0, w - 1, h - 1);
+  if (blink_type) {
+    gdk_draw_rectangle(win, gc1, TRUE, 5, 5, w / 3 - 5, h - 10);
+    gdk_draw_rectangle(win, gc2, TRUE, w / 3, 5, w / 3, h - 10);
+    gdk_draw_rectangle(win, gc1, TRUE, 2 * w / 3, 5, w / 3 - 5, h - 10);
+  } else {
+    gdk_draw_rectangle(win, gc1, TRUE, 5, 5, w - 10, h / 3 - 5);
+    gdk_draw_rectangle(win, gc2, TRUE, 5, h / 3, w - 10, h / 3);
+    gdk_draw_rectangle(win, gc1, TRUE, 5, 2 * h / 3, w - 10, h / 3 - 5);
+  }
+  gdk_draw_rectangle(win, gc, FALSE, 0, 0, w - 1, h - 1);
 }
 
-static gboolean blink_timeout(gpointer data)
-{
-	GtkWidget *widget = (GtkWidget *) data;
-	blink_step = !blink_step;
-	blink_draw(widget);
-	return TRUE;
+static gboolean blink_timeout(gpointer data) {
+  GtkWidget *widget = (GtkWidget *)data;
+  blink_step = !blink_step;
+  blink_draw(widget);
+  return TRUE;
 }
 
-static void blink_init(GtkWidget * widget)
-{
-	blink_type = 0;
-	blink_step = 0;
-	timeout = gtk_timeout_add(1000, blink_timeout, widget);
+static void blink_init(GtkWidget *widget) {
+  blink_type = 0;
+  blink_step = 0;
+  timeout = gtk_timeout_add(1000, blink_timeout, widget);
 }
 
-void blink_cycle(G_GNUC_UNUSED GtkWidget * widget)
-{
-	blink_type = !blink_type;
+void blink_cycle(G_GNUC_UNUSED GtkWidget *widget) { blink_type = !blink_type; }
+
+static void blink_close(G_GNUC_UNUSED GtkWidget *widget) {
+  gtk_timeout_remove(timeout);
 }
 
-static void blink_close(G_GNUC_UNUSED GtkWidget * widget)
-{
-	gtk_timeout_remove(timeout);
-}
-
-G_MODULE_EXPORT struct test_ops blink_ops = {
-	.init = blink_init,
-	.draw = blink_draw,
-	.cycle = blink_cycle,
-	.close = blink_close
-};
+G_MODULE_EXPORT struct test_ops blink_ops = {.init = blink_init,
+                                             .draw = blink_draw,
+                                             .cycle = blink_cycle,
+                                             .close = blink_close};

--- a/test_bright_pixels.c
+++ b/test_bright_pixels.c
@@ -20,42 +20,39 @@
 
 #include <config.h>
 
-#include <stdio.h>
 #include <gtk/gtk.h>
+#include <stdio.h>
 
 #include "callbacks.h"
 
 #define COLOR_COUNT 5
-static const int color_cycle[COLOR_COUNT]={COLOR_RED,COLOR_GREEN,COLOR_BLUE,COLOR_WHITE,COLOR_BLACK};
+static const int color_cycle[COLOR_COUNT] = {COLOR_RED, COLOR_GREEN, COLOR_BLUE,
+                                             COLOR_WHITE, COLOR_BLACK};
 static int current_color_idx;
 
-static void bright_pixels_init(G_GNUC_UNUSED GtkWidget * widget)
-{
-	current_color_idx = 0;
+static void bright_pixels_init(G_GNUC_UNUSED GtkWidget *widget) {
+  current_color_idx = 0;
 }
 
-static void bright_pixels_cycle(G_GNUC_UNUSED GtkWidget * widget)
-{
-	current_color_idx++;
-	if(current_color_idx == COLOR_COUNT)
-		current_color_idx = 0;
+static void bright_pixels_cycle(G_GNUC_UNUSED GtkWidget *widget) {
+  current_color_idx++;
+  if (current_color_idx == COLOR_COUNT)
+    current_color_idx = 0;
 }
 
-static void bright_pixels_draw(GtkWidget * widget)
-{
-	GdkWindow *win = gtk_widget_get_window(widget);
-	gint w, h;
+static void bright_pixels_draw(GtkWidget *widget) {
+  GdkWindow *win = gtk_widget_get_window(widget);
+  gint w, h;
 
-	gdk_drawable_get_size(win, &w, &h);
-	gdk_gc_set_rgb_fg_color(gc, &fgcolors[color_cycle[current_color_idx]]);
-	gdk_draw_rectangle(win, gc, 1, 0, 0, w, h);
+  gdk_drawable_get_size(win, &w, &h);
+  gdk_gc_set_rgb_fg_color(gc, &fgcolors[color_cycle[current_color_idx]]);
+  gdk_draw_rectangle(win, gc, 1, 0, 0, w, h);
 
-	gdk_gc_set_rgb_fg_color(gc, &fgcolors[COLOR_WHITE]);
+  gdk_gc_set_rgb_fg_color(gc, &fgcolors[COLOR_WHITE]);
 }
 
-G_MODULE_EXPORT struct test_ops bright_pixels_ops = {
-		.init = bright_pixels_init,
-		.draw = bright_pixels_draw,
-		.cycle = bright_pixels_cycle,
-		.close = NULL
-};
+G_MODULE_EXPORT struct test_ops bright_pixels_ops = {.init = bright_pixels_init,
+                                                     .draw = bright_pixels_draw,
+                                                     .cycle =
+                                                         bright_pixels_cycle,
+                                                     .close = NULL};

--- a/test_grid.c
+++ b/test_grid.c
@@ -29,40 +29,33 @@
 
 static gint grid_step;
 
-static void grid_init(G_GNUC_UNUSED GtkWidget * widget)
-{
-	grid_step = GRID_STEP;
+static void grid_init(G_GNUC_UNUSED GtkWidget *widget) {
+  grid_step = GRID_STEP;
 }
 
-static void grid_cycle(G_GNUC_UNUSED GtkWidget * widget)
-{
-	grid_step /= 2;
-	if (grid_step < GRID_STEP_MIN)
-		grid_step = GRID_STEP;
+static void grid_cycle(G_GNUC_UNUSED GtkWidget *widget) {
+  grid_step /= 2;
+  if (grid_step < GRID_STEP_MIN)
+    grid_step = GRID_STEP;
 }
 
-static void grid_draw(GtkWidget * widget)
-{
-	GdkWindow *win = gtk_widget_get_window(widget);
-	gint w, h;
-	gint i;
-	gint d;
+static void grid_draw(GtkWidget *widget) {
+  GdkWindow *win = gtk_widget_get_window(widget);
+  gint w, h;
+  gint i;
+  gint d;
 
-	gdk_drawable_get_size(win, &w, &h);
+  gdk_drawable_get_size(win, &w, &h);
 
-	d = w / 4;
-	if (d > h / 4)
-		d = h / 4;
+  d = w / 4;
+  if (d > h / 4)
+    d = h / 4;
 
-	for (i = ((w - 1) % grid_step) / 2; i < w; i += grid_step)
-		gdk_draw_line(win, gc, i, 0, i, h - 1);
-	for (i = ((h - 1) % grid_step) / 2; i < h; i += grid_step)
-		gdk_draw_line(win, gc, 0, i, w - 1, i);
+  for (i = ((w - 1) % grid_step) / 2; i < w; i += grid_step)
+    gdk_draw_line(win, gc, i, 0, i, h - 1);
+  for (i = ((h - 1) % grid_step) / 2; i < h; i += grid_step)
+    gdk_draw_line(win, gc, 0, i, w - 1, i);
 }
 
 G_MODULE_EXPORT struct test_ops grid_ops = {
-	.init = grid_init,
-	.draw = grid_draw,
-	.cycle = grid_cycle,
-	.close = NULL
-};
+    .init = grid_init, .draw = grid_draw, .cycle = grid_cycle, .close = NULL};

--- a/test_horizontal.c
+++ b/test_horizontal.c
@@ -29,39 +29,33 @@
 
 static gint horizontal_step;
 
-static void horizontal_init(G_GNUC_UNUSED GtkWidget * widget)
-{
-	horizontal_step = GRID_STEP;
+static void horizontal_init(G_GNUC_UNUSED GtkWidget *widget) {
+  horizontal_step = GRID_STEP;
 }
 
-static void horizontal_cycle(G_GNUC_UNUSED GtkWidget * widget)
-{
-	horizontal_step /= 2;
-	if (horizontal_step < GRID_STEP_MIN)
-		horizontal_step = GRID_STEP;
+static void horizontal_cycle(G_GNUC_UNUSED GtkWidget *widget) {
+  horizontal_step /= 2;
+  if (horizontal_step < GRID_STEP_MIN)
+    horizontal_step = GRID_STEP;
 }
 
-static void horizontal_draw(GtkWidget * widget)
-{
-	GdkWindow *win = gtk_widget_get_window(widget);
-	gint w, h;
-	gint i;
-	gint d;
+static void horizontal_draw(GtkWidget *widget) {
+  GdkWindow *win = gtk_widget_get_window(widget);
+  gint w, h;
+  gint i;
+  gint d;
 
-	gdk_drawable_get_size(win, &w, &h);
+  gdk_drawable_get_size(win, &w, &h);
 
-	d = w / 4;
-	if (d > h / 4)
-		d = h / 4;
+  d = w / 4;
+  if (d > h / 4)
+    d = h / 4;
 
-	for (i = ((h - 1) % horizontal_step) / 2; i < h;
-	     i += horizontal_step)
-		gdk_draw_line(win, gc, 0, i, w - 1, i);
+  for (i = ((h - 1) % horizontal_step) / 2; i < h; i += horizontal_step)
+    gdk_draw_line(win, gc, 0, i, w - 1, i);
 }
 
-G_MODULE_EXPORT struct test_ops horizontal_ops = {
-	.init = horizontal_init,
-	.draw = horizontal_draw,
-	.cycle = horizontal_cycle,
-	.close = NULL
-};
+G_MODULE_EXPORT struct test_ops horizontal_ops = {.init = horizontal_init,
+                                                  .draw = horizontal_draw,
+                                                  .cycle = horizontal_cycle,
+                                                  .close = NULL};

--- a/test_lcdalign.c
+++ b/test_lcdalign.c
@@ -23,35 +23,31 @@
 
 #include "callbacks.h"
 
-static void lcdalign_draw(GtkWidget * widget)
-{
-	GdkWindow *win = gtk_widget_get_window(widget);
-	GdkGC *linegc = gdk_gc_new(win);
-	gint w, h;
-	gint i;
-	gint8 d[] = {1, 1};
+static void lcdalign_draw(GtkWidget *widget) {
+  GdkWindow *win = gtk_widget_get_window(widget);
+  GdkGC *linegc = gdk_gc_new(win);
+  gint w, h;
+  gint i;
+  gint8 d[] = {1, 1};
 
-	gdk_drawable_get_size(win, &w, &h);
+  gdk_drawable_get_size(win, &w, &h);
 
-	/* Border */
-	gdk_draw_line(win, gc, 0, 0, w - 1, 0);
-	gdk_draw_line(win, gc, 0, 0, 0, h - 1);
-	gdk_draw_line(win, gc, w - 1, 0, w - 1, h - 1);
-	gdk_draw_line(win, gc, 0, h - 1, w - 1, h - 1);
+  /* Border */
+  gdk_draw_line(win, gc, 0, 0, w - 1, 0);
+  gdk_draw_line(win, gc, 0, 0, 0, h - 1);
+  gdk_draw_line(win, gc, w - 1, 0, w - 1, h - 1);
+  gdk_draw_line(win, gc, 0, h - 1, w - 1, h - 1);
 
-	/* Pattern */
-	gdk_gc_copy(linegc, gc);
-	gdk_gc_set_line_attributes(linegc, 1, GDK_LINE_ON_OFF_DASH, GDK_CAP_NOT_LAST, GDK_JOIN_MITER);
-	gdk_gc_set_dashes(linegc, 0, d, 2);
-	for (i = 1; i < h - 1; i++)
-		gdk_draw_line(win, linegc, (i % 2) + 1, i, w - 1, i);
+  /* Pattern */
+  gdk_gc_copy(linegc, gc);
+  gdk_gc_set_line_attributes(linegc, 1, GDK_LINE_ON_OFF_DASH, GDK_CAP_NOT_LAST,
+                             GDK_JOIN_MITER);
+  gdk_gc_set_dashes(linegc, 0, d, 2);
+  for (i = 1; i < h - 1; i++)
+    gdk_draw_line(win, linegc, (i % 2) + 1, i, w - 1, i);
 
-	g_object_unref(linegc);
+  g_object_unref(linegc);
 }
 
 G_MODULE_EXPORT struct test_ops lcdalign_ops = {
-	.init = NULL,
-	.draw = lcdalign_draw,
-	.cycle = NULL,
-	.close = NULL
-};
+    .init = NULL, .draw = lcdalign_draw, .cycle = NULL, .close = NULL};

--- a/test_text.c
+++ b/test_text.c
@@ -20,20 +20,19 @@
 
 #include <config.h>
 
-#include <stdio.h>
 #include <gtk/gtk.h>
+#include <stdio.h>
 
 #include "callbacks.h"
 
 static gchar *fontnames[] = {
-	"-adobe-times-medium-r-normal-*-*-80-*-*-p-*-iso8859-1",
-	"-adobe-times-medium-r-normal-*-*-100-*-*-p-*-iso8859-1",
-	"-adobe-times-medium-r-normal-*-*-120-*-*-p-*-iso8859-1",
-	"-adobe-times-medium-r-normal-*-*-140-*-*-p-*-iso8859-1",
-	"-adobe-times-medium-r-normal-*-*-180-*-*-p-*-iso8859-1",
-	"-adobe-times-medium-r-normal-*-*-240-*-*-p-*-iso8859-1",
-	NULL
-};
+    "-adobe-times-medium-r-normal-*-*-80-*-*-p-*-iso8859-1",
+    "-adobe-times-medium-r-normal-*-*-100-*-*-p-*-iso8859-1",
+    "-adobe-times-medium-r-normal-*-*-120-*-*-p-*-iso8859-1",
+    "-adobe-times-medium-r-normal-*-*-140-*-*-p-*-iso8859-1",
+    "-adobe-times-medium-r-normal-*-*-180-*-*-p-*-iso8859-1",
+    "-adobe-times-medium-r-normal-*-*-240-*-*-p-*-iso8859-1",
+    NULL};
 
 static gint font_num;
 
@@ -43,60 +42,53 @@ static gchar text[] =
 GdkFont *font;
 gint baselineskip, textwidth;
 
-static void font_init(G_GNUC_UNUSED GtkWidget * widget)
-{
-	gint lbear, rbear, width, asc, desc;
+static void font_init(G_GNUC_UNUSED GtkWidget *widget) {
+  gint lbear, rbear, width, asc, desc;
 
-	font = gdk_font_load(fontnames[font_num]);
+  font = gdk_font_load(fontnames[font_num]);
 
-	if (!font) {
-		printf("Cannot load font %s, trying 'fixed'.\n",
-		       fontnames[font_num]);
-		font = gdk_font_load("fixed");
-	}
+  if (!font) {
+    printf("Cannot load font %s, trying 'fixed'.\n", fontnames[font_num]);
+    font = gdk_font_load("fixed");
+  }
 
-	gdk_string_extents(font, text, &lbear, &rbear, &width, &asc,
-			   &desc);
-	baselineskip = 6 * (asc + desc) / 5;	/* 1.2x text height */
-	textwidth = width + baselineskip;	/* the actual width plus space */
+  gdk_string_extents(font, text, &lbear, &rbear, &width, &asc, &desc);
+  baselineskip = 6 * (asc + desc) / 5; /* 1.2x text height */
+  textwidth = width + baselineskip;    /* the actual width plus space */
 }
 
-static void text_init(GtkWidget * widget)
-{
-	font_num = 1;
-	font_init(widget);
+static void text_init(GtkWidget *widget) {
+  font_num = 1;
+  font_init(widget);
 }
 
-static void text_draw(GtkWidget * widget)
-{
-	GdkWindow *win = gtk_widget_get_window(widget);
-	gint w, h;
-	gint x, y;
+static void text_draw(GtkWidget *widget) {
+  GdkWindow *win = gtk_widget_get_window(widget);
+  gint w, h;
+  gint x, y;
 
-	gdk_drawable_get_size(win, &w, &h);
+  gdk_drawable_get_size(win, &w, &h);
 
-	x = w + textwidth;
-	for (y = 0; y < h; y += baselineskip)
-		for (x -= w + textwidth; x < w; x += textwidth)
-			gdk_draw_string(win, font, gc, x, y, text);
+  x = w + textwidth;
+  for (y = 0; y < h; y += baselineskip)
+    for (x -= w + textwidth; x < w; x += textwidth)
+      gdk_draw_string(win, font, gc, x, y, text);
 }
 
-static void text_close(G_GNUC_UNUSED GtkWidget * widget)
-{
-	gdk_font_unref(font);
+static void text_close(G_GNUC_UNUSED GtkWidget *widget) {
+  gdk_font_unref(font);
 }
 
-static void text_cycle(GtkWidget * widget)
-{
-	gdk_font_unref(font);
-	if (fontnames[++font_num] == NULL)
-		font_num = 0;
-	font_init(widget);
+static void text_cycle(GtkWidget *widget) {
+  gdk_font_unref(font);
+  if (fontnames[++font_num] == NULL)
+    font_num = 0;
+  font_init(widget);
 }
 
 G_MODULE_EXPORT struct test_ops text_ops = {
-	.init = text_init,
-	.draw = text_draw,
-	.cycle = text_cycle,
-	.close = text_close,
+    .init = text_init,
+    .draw = text_draw,
+    .cycle = text_cycle,
+    .close = text_close,
 };

--- a/test_vertical.c
+++ b/test_vertical.c
@@ -29,38 +29,33 @@
 
 static gint vertical_step;
 
-static void vertical_init(G_GNUC_UNUSED GtkWidget * widget)
-{
-	vertical_step = GRID_STEP;
+static void vertical_init(G_GNUC_UNUSED GtkWidget *widget) {
+  vertical_step = GRID_STEP;
 }
 
-static void vertical_cycle(G_GNUC_UNUSED GtkWidget * widget)
-{
-	vertical_step /= 2;
-	if (vertical_step < GRID_STEP_MIN)
-		vertical_step = GRID_STEP;
+static void vertical_cycle(G_GNUC_UNUSED GtkWidget *widget) {
+  vertical_step /= 2;
+  if (vertical_step < GRID_STEP_MIN)
+    vertical_step = GRID_STEP;
 }
 
-static void vertical_draw(GtkWidget * widget)
-{
-	GdkWindow *win = gtk_widget_get_window(widget);
-	gint w, h;
-	gint i;
-	gint d;
+static void vertical_draw(GtkWidget *widget) {
+  GdkWindow *win = gtk_widget_get_window(widget);
+  gint w, h;
+  gint i;
+  gint d;
 
-	gdk_drawable_get_size(win, &w, &h);
+  gdk_drawable_get_size(win, &w, &h);
 
-	d = w / 4;
-	if (d > h / 4)
-		d = h / 4;
+  d = w / 4;
+  if (d > h / 4)
+    d = h / 4;
 
-	for (i = ((w - 1) % vertical_step) / 2; i < w; i += vertical_step)
-		gdk_draw_line(win, gc, i, 0, i, h - 1);
+  for (i = ((w - 1) % vertical_step) / 2; i < w; i += vertical_step)
+    gdk_draw_line(win, gc, i, 0, i, h - 1);
 }
 
-G_MODULE_EXPORT struct test_ops vertical_ops = {
-	.init = vertical_init,
-	.draw = vertical_draw,
-	.cycle = vertical_cycle,
-	.close = NULL
-};
+G_MODULE_EXPORT struct test_ops vertical_ops = {.init = vertical_init,
+                                                .draw = vertical_draw,
+                                                .cycle = vertical_cycle,
+                                                .close = NULL};


### PR DESCRIPTION
This pull request does not introduce any functional changes to the code. I just wanted to propose to format the code automatically with `clang-format` in future. For this reason I added a **default** `.clang-format` file and formatted the code accordingly.

I tried to create a clang-format configuration which was better suited to the currently existing codebase than the default one. But the handling of tabs proved to be very difficult, especially for continued function parameter lists.

I guess this pull request is not for merging directly, but rather for discussion.

If there is an automatic formatting in place already and I just overlooked it, this pull request can be rejected gladly.

PS: This is not about cheaply making me the "king of `git blame`". Any port to a newer GTK version or another toolkit should touch most lines anyhow and flush these changes down the Git history.