### PR TITLE
Various minor adjustments to the code and preparation for GTK+ 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,14 @@ Unpack the distribution using the following command:
 Change the directory to the source directory:
     cd screentest-<version>
 Set it up for your system:
-    ./configure
-You can run "./configure --help" for details of the configuration process.
+    meson setup builddir
 
 ### 2. COMPILING THE PROGRAM
 
-Run "make" (On BSD systems, you might want to use "gmake"). This will compile
-the "screentest" program. Since the program is mostly standalone, you can now
-verify their function by running them in the current directory (calling
-"./screentest").
+Run "meson compile". This will compile the "screentest" program. Since the
+program is mostly standalone, you can now verify their function by running them
+in the current directory (calling "./screentest").
 
 ### 3. INSTALLING
 
-Run "make install".
+Run "meson install".

--- a/callbacks.c
+++ b/callbacks.c
@@ -231,3 +231,15 @@ G_MODULE_EXPORT void on_bg_color_activate(G_GNUC_UNUSED GtkMenuItem *menuitem,
   }
   gtk_widget_hide(GTK_WIDGET(bg_color_selector));
 }
+
+void set_color_bg(cairo_t *cr) {
+  cairo_set_source_rgb(cr, bg_color->red / (double)UINT16_MAX,
+                       bg_color->green / (double)UINT16_MAX,
+                       bg_color->blue / (double)UINT16_MAX);
+}
+
+void set_color_fg(cairo_t *cr) {
+  cairo_set_source_rgb(cr, fg_color->red / (double)UINT16_MAX,
+                       fg_color->green / (double)UINT16_MAX,
+                       fg_color->blue / (double)UINT16_MAX);
+}

--- a/callbacks.h
+++ b/callbacks.h
@@ -51,4 +51,7 @@ extern GdkColor fgcolors[];
 extern GdkColor *fg_color;
 extern GdkColor grays[];
 
+void set_color_bg(cairo_t *cr);
+void set_color_fg(cairo_t *cr);
+
 #endif // SCREENTEST_CALLBACKS_H

--- a/callbacks.h
+++ b/callbacks.h
@@ -18,6 +18,9 @@
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
  */
 
+#ifndef SCREENTEST_CALLBACKS_H
+#define SCREENTEST_CALLBACKS_H
+
 #include <gtk/gtk.h>
 
 struct test_ops {
@@ -47,3 +50,5 @@ extern GdkGC *gc, *backgc;
 extern GdkColor fgcolors[];
 extern GdkColor *fg_color;
 extern GdkColor grays[];
+
+#endif // SCREENTEST_CALLBACKS_H

--- a/gettext.h
+++ b/gettext.h
@@ -15,8 +15,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _LIBGETTEXT_H
-#define _LIBGETTEXT_H 1
+#ifndef SCREENTEST_LIBGETTEXT_H
+#define SCREENTEST_LIBGETTEXT_H 1
 
 /* NLS can be disabled through the configure --disable-nls option.  */
 #if ENABLE_NLS
@@ -279,4 +279,4 @@ inline
   return (n == 1 ? msgid : msgid_plural);
 }
 
-#endif /* _LIBGETTEXT_H */
+#endif // SCREENTEST_LIBGETTEXT_H

--- a/main.h
+++ b/main.h
@@ -18,11 +18,11 @@
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
  */
 
-#ifndef _MAIN_H
-#define _MAIN_H 1
+#ifndef SCREENTEST_MAIN_H
+#define SCREENTEST_MAIN_H 1
 
 #include <gtk/gtk.h>
 
 extern GtkBuilder *builder;
 
-#endif /* _MAIN_H */
+#endif // SCREENTEST_MAIN_H

--- a/meson.build
+++ b/meson.build
@@ -49,6 +49,7 @@ screentest_srcs = [
 executable(
   meson.project_name(),
   'main.c',
+  c_args: '-DGTK_DISABLE_SINGLE_INCLUDES',
   dependencies: screentest_deps,
   install: true,
   sources: screentest_srcs,

--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,7 @@ screentest_srcs = [
 executable(
   meson.project_name(),
   'main.c',
-  c_args: '-DGTK_DISABLE_SINGLE_INCLUDES',
+  c_args: '-DGSEAL_ENABLE -DGTK_DISABLE_SINGLE_INCLUDES',
   dependencies: screentest_deps,
   install: true,
   sources: screentest_srcs,

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,7 @@ project(
 
 i18n = import('i18n')
 
+cairo_dep = dependency('cairo', version: '>= 1.0')
 gmodule_dep = dependency('gmodule-2.0', version: '>= 1.1.3')
 gtk_dep = dependency('gtk+-2.0', version: '>= 2.24')
 screentest_deps = [

--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,7 @@ screentest_srcs = [
 executable(
   meson.project_name(),
   'main.c',
-  c_args: '-DGSEAL_ENABLE -DGTK_DISABLE_SINGLE_INCLUDES',
+  c_args: '-DGSEAL_ENABLE -DGTK_DISABLE_DEPRECATED -DGTK_DISABLE_SINGLE_INCLUDES',
   dependencies: screentest_deps,
   install: true,
   sources: screentest_srcs,

--- a/test_basic.c
+++ b/test_basic.c
@@ -74,7 +74,8 @@ static void basic_draw(GtkWidget *widget) {
       N_("Right Button - menu"),
   };
 
-  gdk_drawable_get_size(win, &w, &h);
+  h = gdk_window_get_height(win);
+  w = gdk_window_get_width(win);
 
   for (i = ((w - 1) % BASIC_STEP) / 2; i < w; i += BASIC_STEP)
     gdk_draw_line(win, gc, i, 0, i, h - 1);

--- a/test_blink.c
+++ b/test_blink.c
@@ -67,13 +67,13 @@ static gboolean blink_timeout(gpointer data) {
 static void blink_init(GtkWidget *widget) {
   blink_type = 0;
   blink_step = 0;
-  timeout = gtk_timeout_add(1000, blink_timeout, widget);
+  timeout = g_timeout_add(1000, blink_timeout, widget);
 }
 
 void blink_cycle(G_GNUC_UNUSED GtkWidget *widget) { blink_type = !blink_type; }
 
 static void blink_close(G_GNUC_UNUSED GtkWidget *widget) {
-  gtk_timeout_remove(timeout);
+  g_source_remove(timeout);
 }
 
 G_MODULE_EXPORT struct test_ops blink_ops = {.init = blink_init,

--- a/test_blink.c
+++ b/test_blink.c
@@ -29,32 +29,58 @@ static guint timeout;
 static gint blink_type;
 static gint blink_step;
 
+void (*set_color1)(cairo_t *cr);
+void (*set_color2)(cairo_t *cr);
+
 static void blink_draw(GtkWidget *widget) {
+  cairo_t *cr;
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
-  GdkGC *gc1, *gc2;
 
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
 
   if (blink_step) {
-    gc1 = backgc;
-    gc2 = gc;
+    set_color1 = set_color_bg;
+    set_color2 = set_color_fg;
   } else {
-    gc1 = gc;
-    gc2 = backgc;
+    set_color1 = set_color_fg;
+    set_color2 = set_color_bg;
   }
 
+  cr = gdk_cairo_create(gtk_widget_get_window(widget));
+
+  set_color_fg(cr);
+  cairo_paint(cr);
+
+  set_color_bg(cr);
+  cairo_rectangle(cr, 1, 1, w - 2, h - 2);
+  cairo_fill(cr);
+
   if (blink_type) {
-    gdk_draw_rectangle(win, gc1, TRUE, 5, 5, w / 3 - 5, h - 10);
-    gdk_draw_rectangle(win, gc2, TRUE, w / 3, 5, w / 3, h - 10);
-    gdk_draw_rectangle(win, gc1, TRUE, 2 * w / 3, 5, w / 3 - 5, h - 10);
+    set_color1(cr);
+    cairo_rectangle(cr, 5, 5, w / 3 - 5, h - 10);
+    cairo_fill(cr);
+    set_color2(cr);
+    cairo_rectangle(cr, w / 3, 5, w / 3, h - 10);
+    cairo_fill(cr);
+    set_color1(cr);
+    cairo_rectangle(cr, 2 * w / 3, 5, w / 3 - 5, h - 10);
+    cairo_fill(cr);
   } else {
-    gdk_draw_rectangle(win, gc1, TRUE, 5, 5, w - 10, h / 3 - 5);
-    gdk_draw_rectangle(win, gc2, TRUE, 5, h / 3, w - 10, h / 3);
-    gdk_draw_rectangle(win, gc1, TRUE, 5, 2 * h / 3, w - 10, h / 3 - 5);
+    set_color1(cr);
+    cairo_rectangle(cr, 5, 5, w - 10, h / 3 - 5);
+    cairo_fill(cr);
+    set_color2(cr);
+    cairo_rectangle(cr, 5, h / 3, w - 10, h / 3);
+    cairo_fill(cr);
+    set_color1(cr);
+    cairo_rectangle(cr, 5, 2 * h / 3, w - 10, h / 3 - 5);
+    cairo_fill(cr);
   }
-  gdk_draw_rectangle(win, gc, FALSE, 0, 0, w - 1, h - 1);
+
+  cairo_destroy(cr);
+  cr = NULL;
 }
 
 static gboolean blink_timeout(gpointer data) {

--- a/test_blink.c
+++ b/test_blink.c
@@ -34,7 +34,8 @@ static void blink_draw(GtkWidget *widget) {
   gint w, h;
   GdkGC *gc1, *gc2;
 
-  gdk_drawable_get_size(win, &w, &h);
+  h = gdk_window_get_height(win);
+  w = gdk_window_get_width(win);
 
   if (blink_step) {
     gc1 = backgc;

--- a/test_bright_pixels.c
+++ b/test_bright_pixels.c
@@ -44,7 +44,9 @@ static void bright_pixels_draw(GtkWidget *widget) {
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
 
-  gdk_drawable_get_size(win, &w, &h);
+  h = gdk_window_get_height(win);
+  w = gdk_window_get_width(win);
+
   gdk_gc_set_rgb_fg_color(gc, &fgcolors[color_cycle[current_color_idx]]);
   gdk_draw_rectangle(win, gc, 1, 0, 0, w, h);
 

--- a/test_bright_pixels.c
+++ b/test_bright_pixels.c
@@ -41,16 +41,19 @@ static void bright_pixels_cycle(G_GNUC_UNUSED GtkWidget *widget) {
 }
 
 static void bright_pixels_draw(GtkWidget *widget) {
-  GdkWindow *win = gtk_widget_get_window(widget);
-  gint w, h;
+  GdkColor *col;
+  cairo_t *cr;
 
-  h = gdk_window_get_height(win);
-  w = gdk_window_get_width(win);
+  cr = gdk_cairo_create(gtk_widget_get_window(widget));
 
-  gdk_gc_set_rgb_fg_color(gc, &fgcolors[color_cycle[current_color_idx]]);
-  gdk_draw_rectangle(win, gc, 1, 0, 0, w, h);
+  col = &fgcolors[color_cycle[current_color_idx]];
+  cairo_set_source_rgb(cr, col->red / (double)UINT16_MAX,
+                       col->green / (double)UINT16_MAX,
+                       col->blue / (double)UINT16_MAX);
+  cairo_paint(cr);
 
-  gdk_gc_set_rgb_fg_color(gc, &fgcolors[COLOR_WHITE]);
+  cairo_destroy(cr);
+  cr = NULL;
 }
 
 G_MODULE_EXPORT struct test_ops bright_pixels_ops = {.init = bright_pixels_init,

--- a/test_grid.c
+++ b/test_grid.c
@@ -45,7 +45,8 @@ static void grid_draw(GtkWidget *widget) {
   gint i;
   gint d;
 
-  gdk_drawable_get_size(win, &w, &h);
+  h = gdk_window_get_height(win);
+  w = gdk_window_get_width(win);
 
   d = w / 4;
   if (d > h / 4)

--- a/test_grid.c
+++ b/test_grid.c
@@ -43,14 +43,9 @@ static void grid_draw(GtkWidget *widget) {
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
   gint i;
-  gint d;
 
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
-
-  d = w / 4;
-  if (d > h / 4)
-    d = h / 4;
 
   for (i = ((w - 1) % grid_step) / 2; i < w; i += grid_step)
     gdk_draw_line(win, gc, i, 0, i, h - 1);

--- a/test_grid.c
+++ b/test_grid.c
@@ -40,6 +40,7 @@ static void grid_cycle(G_GNUC_UNUSED GtkWidget *widget) {
 }
 
 static void grid_draw(GtkWidget *widget) {
+  cairo_t *cr;
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
   gint i;
@@ -47,10 +48,23 @@ static void grid_draw(GtkWidget *widget) {
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
 
-  for (i = ((w - 1) % grid_step) / 2; i < w; i += grid_step)
-    gdk_draw_line(win, gc, i, 0, i, h - 1);
-  for (i = ((h - 1) % grid_step) / 2; i < h; i += grid_step)
-    gdk_draw_line(win, gc, 0, i, w - 1, i);
+  cr = gdk_cairo_create(gtk_widget_get_window(widget));
+
+  set_color_bg(cr);
+  cairo_paint(cr);
+
+  set_color_fg(cr);
+  for (i = ((w - 1) % grid_step) / 2; i < w; i += grid_step) {
+    cairo_rectangle(cr, i, 0, 1, w - 1);
+    cairo_fill(cr);
+  }
+  for (i = ((h - 1) % grid_step) / 2; i < h; i += grid_step) {
+    cairo_rectangle(cr, 0, i, w - 1, 1);
+    cairo_fill(cr);
+  }
+
+  cairo_destroy(cr);
+  cr = NULL;
 }
 
 G_MODULE_EXPORT struct test_ops grid_ops = {

--- a/test_horizontal.c
+++ b/test_horizontal.c
@@ -43,14 +43,9 @@ static void horizontal_draw(GtkWidget *widget) {
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
   gint i;
-  gint d;
 
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
-
-  d = w / 4;
-  if (d > h / 4)
-    d = h / 4;
 
   for (i = ((h - 1) % horizontal_step) / 2; i < h; i += horizontal_step)
     gdk_draw_line(win, gc, 0, i, w - 1, i);

--- a/test_horizontal.c
+++ b/test_horizontal.c
@@ -40,6 +40,7 @@ static void horizontal_cycle(G_GNUC_UNUSED GtkWidget *widget) {
 }
 
 static void horizontal_draw(GtkWidget *widget) {
+  cairo_t *cr;
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
   gint i;
@@ -47,8 +48,19 @@ static void horizontal_draw(GtkWidget *widget) {
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
 
-  for (i = ((h - 1) % horizontal_step) / 2; i < h; i += horizontal_step)
-    gdk_draw_line(win, gc, 0, i, w - 1, i);
+  cr = gdk_cairo_create(gtk_widget_get_window(widget));
+
+  set_color_bg(cr);
+  cairo_paint(cr);
+
+  set_color_fg(cr);
+  for (i = ((h - 1) % horizontal_step) / 2; i < h; i += horizontal_step) {
+    cairo_rectangle(cr, 0, i, w - 1, 1);
+    cairo_fill(cr);
+  }
+
+  cairo_destroy(cr);
+  cr = NULL;
 }
 
 G_MODULE_EXPORT struct test_ops horizontal_ops = {.init = horizontal_init,

--- a/test_horizontal.c
+++ b/test_horizontal.c
@@ -45,7 +45,8 @@ static void horizontal_draw(GtkWidget *widget) {
   gint i;
   gint d;
 
-  gdk_drawable_get_size(win, &w, &h);
+  h = gdk_window_get_height(win);
+  w = gdk_window_get_width(win);
 
   d = w / 4;
   if (d > h / 4)

--- a/test_lcdalign.c
+++ b/test_lcdalign.c
@@ -30,7 +30,8 @@ static void lcdalign_draw(GtkWidget *widget) {
   gint i;
   gint8 d[] = {1, 1};
 
-  gdk_drawable_get_size(win, &w, &h);
+  h = gdk_window_get_height(win);
+  w = gdk_window_get_width(win);
 
   /* Border */
   gdk_draw_line(win, gc, 0, 0, w - 1, 0);

--- a/test_lcdalign.c
+++ b/test_lcdalign.c
@@ -24,30 +24,33 @@
 #include "callbacks.h"
 
 static void lcdalign_draw(GtkWidget *widget) {
+  cairo_t *cr;
   GdkWindow *win = gtk_widget_get_window(widget);
-  GdkGC *linegc = gdk_gc_new(win);
   gint w, h;
   gint i;
-  gint8 d[] = {1, 1};
+  static const double d[] = {1.0};
 
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
 
-  /* Border */
-  gdk_draw_line(win, gc, 0, 0, w - 1, 0);
-  gdk_draw_line(win, gc, 0, 0, 0, h - 1);
-  gdk_draw_line(win, gc, w - 1, 0, w - 1, h - 1);
-  gdk_draw_line(win, gc, 0, h - 1, w - 1, h - 1);
+  cr = gdk_cairo_create(gtk_widget_get_window(widget));
+
+  /* Background/Border */
+  set_color_fg(cr);
+  cairo_paint(cr);
 
   /* Pattern */
-  gdk_gc_copy(linegc, gc);
-  gdk_gc_set_line_attributes(linegc, 1, GDK_LINE_ON_OFF_DASH, GDK_CAP_NOT_LAST,
-                             GDK_JOIN_MITER);
-  gdk_gc_set_dashes(linegc, 0, d, 2);
-  for (i = 1; i < h - 1; i++)
-    gdk_draw_line(win, linegc, (i % 2) + 1, i, w - 1, i);
+  set_color_bg(cr);
+  cairo_set_line_width(cr, 1.0);
+  for (i = 1; i < h - 1; i += 1) {
+    cairo_set_dash(cr, d, 1, (i % 2) + 1);
+    cairo_move_to(cr, 1, i + 0.5);
+    cairo_line_to(cr, w - 1, i + 0.5);
+    cairo_stroke(cr);
+  }
 
-  g_object_unref(linegc);
+  cairo_destroy(cr);
+  cr = NULL;
 }
 
 G_MODULE_EXPORT struct test_ops lcdalign_ops = {

--- a/test_text.c
+++ b/test_text.c
@@ -67,7 +67,8 @@ static void text_draw(GtkWidget *widget) {
   gint w, h;
   gint x, y;
 
-  gdk_drawable_get_size(win, &w, &h);
+  h = gdk_window_get_height(win);
+  w = gdk_window_get_width(win);
 
   x = w + textwidth;
   for (y = 0; y < h; y += baselineskip)

--- a/test_vertical.c
+++ b/test_vertical.c
@@ -40,6 +40,7 @@ static void vertical_cycle(G_GNUC_UNUSED GtkWidget *widget) {
 }
 
 static void vertical_draw(GtkWidget *widget) {
+  cairo_t *cr;
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
   gint i;
@@ -47,8 +48,19 @@ static void vertical_draw(GtkWidget *widget) {
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
 
-  for (i = ((w - 1) % vertical_step) / 2; i < w; i += vertical_step)
-    gdk_draw_line(win, gc, i, 0, i, h - 1);
+  cr = gdk_cairo_create(gtk_widget_get_window(widget));
+
+  set_color_bg(cr);
+  cairo_paint(cr);
+
+  set_color_fg(cr);
+  for (i = ((w - 1) % vertical_step) / 2; i < w; i += vertical_step) {
+    cairo_rectangle(cr, i, 0, 1, w - 1);
+    cairo_fill(cr);
+  }
+
+  cairo_destroy(cr);
+  cr = NULL;
 }
 
 G_MODULE_EXPORT struct test_ops vertical_ops = {.init = vertical_init,

--- a/test_vertical.c
+++ b/test_vertical.c
@@ -45,7 +45,8 @@ static void vertical_draw(GtkWidget *widget) {
   gint i;
   gint d;
 
-  gdk_drawable_get_size(win, &w, &h);
+  h = gdk_window_get_height(win);
+  w = gdk_window_get_width(win);
 
   d = w / 4;
   if (d > h / 4)

--- a/test_vertical.c
+++ b/test_vertical.c
@@ -43,14 +43,9 @@ static void vertical_draw(GtkWidget *widget) {
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
   gint i;
-  gint d;
 
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
-
-  d = w / 4;
-  if (d > h / 4)
-    d = h / 4;
 
   for (i = ((w - 1) % vertical_step) / 2; i < w; i += vertical_step)
     gdk_draw_line(win, gc, i, 0, i, h - 1);


### PR DESCRIPTION
This pull request makes various minor adjustments all around the codebase and prepares the trivially adjustable tests for a port to GTK+ 3.

I don't know how far your considerations/coding in direction of porting to SDL went. I would have continued with GTK since it should be readily available on most Linux systems anyhow.

If I don't overlook anything the port to GTK+ 3 and beyond should mostly concern the drawing, which would need to be ported to Cairo. I realized this with this pull request, only the test cases containing text are more difficult (I know neither Cairo nor Pango).

I considered porting to GTK 4 directly, but I prefer to maintain a good deal of backwards compatibility. So I'd aim at GTK+ 3 first and then make optional adjustments to GTK 4.