### PR TITLE
Complete replacement of GdkGC by Cairo

### DIFF
--- a/callbacks.c
+++ b/callbacks.c
@@ -33,7 +33,6 @@
 GdkColor fgcolors[COLOR_MAX];
 GdkColor *fg_color, *bg_color;
 GdkColor grays[GRAYS_MAX];
-GdkGC *gc, *backgc;
 int fg_count = COLOR_WHITE;
 
 static GtkWidget *mainwin = NULL;
@@ -78,26 +77,8 @@ G_MODULE_EXPORT void on_mainwin_realize(GtkWidget *widget,
 
   mainwin = widget;
 
-  gc = gdk_gc_new(gtk_widget_get_window(mainwin));
-  backgc = gdk_gc_new(gtk_widget_get_window(mainwin));
-
   if (current_test->init != NULL)
     current_test->init(widget);
-}
-
-static void update_fg_color(void) {
-  gdk_gc_set_rgb_fg_color(gc, fg_color);
-  gdk_gc_set_rgb_bg_color(backgc, fg_color);
-
-  gdk_window_invalidate_rect(gtk_widget_get_window(mainwin), NULL, FALSE);
-}
-
-static void update_bg_color(void) {
-  gdk_rgb_find_color(gtk_widget_get_colormap(GTK_WIDGET(mainwin)), bg_color);
-  gdk_gc_set_rgb_bg_color(gc, bg_color);
-  gdk_gc_set_rgb_fg_color(backgc, bg_color);
-
-  gdk_window_invalidate_rect(gtk_widget_get_window(mainwin), NULL, FALSE);
 }
 
 G_MODULE_EXPORT gboolean
@@ -117,7 +98,7 @@ on_mainwin_button_press_event(GtkWidget *widget, GdkEventButton *event,
       fg_count = COLOR_WHITE;
     gdk_color_free(fg_color);
     fg_color = gdk_color_copy(&fgcolors[fg_count]);
-    update_fg_color();
+    gdk_window_invalidate_rect(gtk_widget_get_window(mainwin), NULL, FALSE);
     break;
   case 3:
     popup = gtk_builder_get_object(builder, "popup");
@@ -197,7 +178,7 @@ G_MODULE_EXPORT void on_fg_color_activate(G_GNUC_UNUSED GtkMenuItem *menuitem,
   switch (gtk_dialog_run(GTK_DIALOG(fg_color_selector))) {
   case GTK_RESPONSE_OK:
     gtk_color_selection_get_current_color(colorsel, fg_color);
-    update_fg_color();
+    gdk_window_invalidate_rect(gtk_widget_get_window(mainwin), NULL, FALSE);
     break;
   case GTK_RESPONSE_CANCEL:
   case GTK_RESPONSE_DELETE_EVENT:
@@ -221,7 +202,7 @@ G_MODULE_EXPORT void on_bg_color_activate(G_GNUC_UNUSED GtkMenuItem *menuitem,
   switch (gtk_dialog_run(GTK_DIALOG(bg_color_selector))) {
   case GTK_RESPONSE_OK:
     gtk_color_selection_get_current_color(colorsel, bg_color);
-    update_bg_color();
+    gdk_window_invalidate_rect(gtk_widget_get_window(mainwin), NULL, FALSE);
     break;
   case GTK_RESPONSE_CANCEL:
   case GTK_RESPONSE_DELETE_EVENT:

--- a/callbacks.h
+++ b/callbacks.h
@@ -46,7 +46,6 @@ enum test_color {
 
 #define GRAYS_MAX COLOR_MAX
 
-extern GdkGC *gc, *backgc;
 extern GdkColor fgcolors[];
 extern GdkColor *fg_color;
 extern GdkColor grays[];

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,6 @@ project(
 
 i18n = import('i18n')
 
-cairo_dep = dependency('cairo', version: '>= 1.0')
 gmodule_dep = dependency('gmodule-2.0', version: '>= 1.1.3')
 gtk_dep = dependency('gtk+-2.0', version: '>= 2.24')
 screentest_deps = [

--- a/test_basic.c
+++ b/test_basic.c
@@ -31,37 +31,32 @@
 
 #define BASIC_STEP 40
 
-static gchar fontname[] =
-    "-adobe-helvetica-bold-r-normal-*-14-*-*-*-p-*-iso8859-1";
-static GdkFont *font;
-
-static void basic_init(G_GNUC_UNUSED GtkWidget *widget) {
-  font = gdk_font_load(fontname);
-
-  if (!font) {
-    printf("Cannot load font %s, trying 'fixed'.\n", fontname);
-    font = gdk_font_load("fixed");
-  }
-}
-
-static void draw_boxes(GdkWindow *win, GdkColor *colors, gint ncols, gint x,
+static void draw_boxes(cairo_t *cr, GdkColor *colors, gint ncols, gint x,
                        gint y, gint d) {
+  GdkColor *col;
   int i;
 
   for (i = 0; i < ncols; i++) {
-    gdk_gc_set_rgb_fg_color(gc, &colors[i]);
+    col = &colors[i];
+    cairo_set_source_rgb(cr, col->red / (double)UINT16_MAX,
+                         col->green / (double)UINT16_MAX,
+                         col->blue / (double)UINT16_MAX);
 
-    gdk_draw_rectangle(win, gc, TRUE, x, y, d, d);
+    cairo_rectangle(cr, x, y, d, d);
+    cairo_fill(cr);
     x += d;
   }
 
-  gdk_gc_set_rgb_fg_color(gc, fg_color);
+  set_color_fg(cr);
 }
 
 static void basic_draw(GtkWidget *widget) {
+  cairo_t *cr;
+  PangoLayout *pl;
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
   gint i, b, d;
+  PangoRectangle ink_rect;
   gint maxwidth, maxheight;
   gint widths[7];
   static gchar *text[] = {
@@ -77,76 +72,102 @@ static void basic_draw(GtkWidget *widget) {
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
 
+  cr = gdk_cairo_create(gtk_widget_get_window(widget));
+  cairo_set_line_width(cr, 1.0);
+
+  pl = pango_cairo_create_layout(cr);
+
+  set_color_bg(cr);
+  cairo_paint(cr);
+
+  set_color_fg(cr);
+
   for (i = ((w - 1) % BASIC_STEP) / 2; i < w; i += BASIC_STEP)
-    gdk_draw_line(win, gc, i, 0, i, h - 1);
+    cairo_rectangle(cr, i, 0, 1, h);
   for (i = ((h - 1) % BASIC_STEP) / 2; i < h; i += BASIC_STEP)
-    gdk_draw_line(win, gc, 0, i, w - 1, i);
+    cairo_rectangle(cr, 0, i, w, 1);
+  cairo_fill(cr);
 
   d = w / 4;
   if (d > h / 4)
     d = h / 4;
 
   maxheight = 0;
-  for (i = 0; i < 7; i++) {
-    int x = gdk_string_height(font, gettext(text[i]));
-    if (x > maxheight)
-      maxheight = x;
-  }
-
   maxwidth = 0;
   for (i = 0; i < 7; i++) {
-    widths[i] = gdk_string_width(font, gettext(text[i]));
+    pango_layout_set_text(pl, gettext(text[i]), -1);
+    pango_layout_get_extents(pl, &ink_rect, NULL);
+    double x = pango_units_to_double(ink_rect.height);
+    if (x > maxheight)
+      maxheight = x;
+    widths[i] = pango_units_to_double(ink_rect.width);
     if (widths[i] > maxwidth)
       maxwidth = widths[i];
   }
 
   maxwidth += 20;
   maxheight = 3 * maxheight / 2;
-  gdk_draw_rectangle(win, gc, FALSE, (w - maxwidth) / 2, d / 2 - 2 * maxheight,
-                     maxwidth, 5 * maxheight);
-  gdk_draw_rectangle(win, gc, FALSE, (w - maxwidth) / 2,
-                     h - d / 2 - 2 * maxheight, maxwidth, 4 * maxheight);
-  gdk_draw_rectangle(win, backgc, TRUE, (w - maxwidth) / 2 + 1,
-                     d / 2 - 2 * maxheight + 1, maxwidth - 1,
-                     5 * maxheight - 1);
-  gdk_draw_rectangle(win, backgc, TRUE, (w - maxwidth) / 2 + 1,
-                     h - d / 2 - 2 * maxheight + 1, maxwidth - 1,
-                     4 * maxheight - 1);
 
-  gdk_draw_string(win, font, gc, (w - widths[0]) / 2, d / 2 - 2 * maxheight / 3,
-                  gettext(text[0]));
-  gdk_draw_string(win, font, gc, (w - widths[1]) / 2, d / 2 + maxheight / 3,
-                  gettext(text[1]));
-  gdk_draw_string(win, font, gc, (w - widths[2]) / 2, d / 2 + 4 * maxheight / 3,
-                  gettext(text[2]));
-  gdk_draw_string(win, font, gc, (w - widths[3]) / 2, d / 2 + 7 * maxheight / 3,
-                  gettext(text[3]));
+  cairo_rectangle(cr, (w - maxwidth) / 2 + 0.5, d / 2 - 2 * maxheight + 0.5,
+                  maxwidth, 5 * maxheight);
+  cairo_rectangle(cr, (w - maxwidth) / 2 + 0.5, h - d / 2 - 2 * maxheight + 0.5,
+                  maxwidth, 4 * maxheight);
+  cairo_stroke(cr);
 
-  gdk_draw_string(win, font, gc, (w - widths[4]) / 2,
-                  h - d / 2 - 2 * maxheight / 3, gettext(text[4]));
-  gdk_draw_string(win, font, gc, (w - widths[5]) / 2, h - d / 2 + maxheight / 3,
-                  gettext(text[5]));
-  gdk_draw_string(win, font, gc, (w - widths[6]) / 2,
-                  h - d / 2 + 4 * maxheight / 3, gettext(text[6]));
+  set_color_bg(cr);
+  cairo_rectangle(cr, (w - maxwidth) / 2 + 1, d / 2 - 2 * maxheight + 1,
+                  maxwidth - 1, 5 * maxheight - 1);
+  cairo_rectangle(cr, (w - maxwidth) / 2 + 1, h - d / 2 - 2 * maxheight + 1,
+                  maxwidth - 1, 4 * maxheight - 1);
+  cairo_fill(cr);
+
+  set_color_fg(cr);
+
+  cairo_move_to(cr, (w - widths[0]) / 2, d / 2 - 4 * maxheight / 3);
+  pango_layout_set_text(pl, gettext(text[0]), -1);
+  pango_cairo_show_layout(cr, pl);
+  cairo_move_to(cr, (w - widths[1]) / 2, d / 2 - maxheight / 3);
+  pango_layout_set_text(pl, gettext(text[1]), -1);
+  pango_cairo_show_layout(cr, pl);
+  cairo_move_to(cr, (w - widths[2]) / 2, d / 2 + 2 * maxheight / 3);
+  pango_layout_set_text(pl, gettext(text[2]), -1);
+  pango_cairo_show_layout(cr, pl);
+  cairo_move_to(cr, (w - widths[3]) / 2, d / 2 + 5 * maxheight / 3);
+  pango_layout_set_text(pl, gettext(text[3]), -1);
+  pango_cairo_show_layout(cr, pl);
+  cairo_move_to(cr, (w - widths[4]) / 2, h - d / 2 - 4 * maxheight / 3);
+  pango_layout_set_text(pl, gettext(text[4]), -1);
+  pango_cairo_show_layout(cr, pl);
+  cairo_move_to(cr, (w - widths[5]) / 2, h - d / 2 - maxheight / 3);
+  pango_layout_set_text(pl, gettext(text[5]), -1);
+  pango_cairo_show_layout(cr, pl);
+  cairo_move_to(cr, (w - widths[6]) / 2, h - d / 2 + 2 * maxheight / 3);
+  pango_layout_set_text(pl, gettext(text[6]), -1);
+  pango_cairo_show_layout(cr, pl);
 
   b = 7 * d / 4;
-  draw_boxes(win, fgcolors, COLOR_MAX, (w - b) / 2, h / 2 - b / COLOR_MAX,
+  draw_boxes(cr, fgcolors, COLOR_MAX, (w - b) / 2, h / 2 - b / COLOR_MAX,
              b / COLOR_MAX);
-  draw_boxes(win, grays, GRAYS_MAX, (w - b) / 2, h / 2, b / GRAYS_MAX);
-  w--;
-  h--;
-  gdk_draw_arc(win, gc, FALSE, 0, 0, d, d, 0, 360 * 64);
-  gdk_draw_arc(win, gc, FALSE, 0, h - d, d, d, 0, 360 * 64);
-  gdk_draw_arc(win, gc, FALSE, w - d, h - d, d, d, 0, 360 * 64);
-  gdk_draw_arc(win, gc, FALSE, w - d, 0, d, d, 0, 360 * 64);
-  gdk_draw_arc(win, gc, FALSE, w / 2 - d, h / 2 - d, d * 2, d * 2, 0, 360 * 64);
+  draw_boxes(cr, grays, GRAYS_MAX, (w - b) / 2, h / 2, b / GRAYS_MAX);
+
+  cairo_arc(cr, 0 + d / 2 + 0.5, 0 + d / 2 + 0.5, d / 2, 0,
+            2 * G_PI); // Upper left
+  cairo_new_sub_path(cr);
+  cairo_arc(cr, 0 + d / 2 + 0.5, h - d / 2 - 0.5, d / 2, 0,
+            2 * G_PI); // Lower left
+  cairo_new_sub_path(cr);
+  cairo_arc(cr, w - d / 2 - 0.5, h - d / 2 - 0.5, d / 2, 0,
+            2 * G_PI); // Lower right
+  cairo_new_sub_path(cr);
+  cairo_arc(cr, w - d / 2 - 0.5, 0 + d / 2 + 0.5, d / 2, 0,
+            2 * G_PI); // Upper right
+  cairo_new_sub_path(cr);
+  cairo_arc(cr, w / 2, h / 2, d, 0, 2 * G_PI);
+  cairo_stroke(cr);
+
+  cairo_destroy(cr);
+  cr = NULL;
 }
 
-static void basic_close(G_GNUC_UNUSED GtkWidget *widget) {
-  gdk_font_unref(font);
-}
-
-G_MODULE_EXPORT struct test_ops basic_ops = {.init = basic_init,
-                                             .draw = basic_draw,
-                                             .cycle = NULL,
-                                             .close = basic_close};
+G_MODULE_EXPORT struct test_ops basic_ops = {
+    .init = NULL, .draw = basic_draw, .cycle = NULL, .close = NULL};

--- a/test_grid.c
+++ b/test_grid.c
@@ -55,11 +55,11 @@ static void grid_draw(GtkWidget *widget) {
 
   set_color_fg(cr);
   for (i = ((w - 1) % grid_step) / 2; i < w; i += grid_step) {
-    cairo_rectangle(cr, i, 0, 1, w - 1);
+    cairo_rectangle(cr, i, 0, 1, h);
     cairo_fill(cr);
   }
   for (i = ((h - 1) % grid_step) / 2; i < h; i += grid_step) {
-    cairo_rectangle(cr, 0, i, w - 1, 1);
+    cairo_rectangle(cr, 0, i, w, 1);
     cairo_fill(cr);
   }
 

--- a/test_grid.c
+++ b/test_grid.c
@@ -56,12 +56,11 @@ static void grid_draw(GtkWidget *widget) {
   set_color_fg(cr);
   for (i = ((w - 1) % grid_step) / 2; i < w; i += grid_step) {
     cairo_rectangle(cr, i, 0, 1, h);
-    cairo_fill(cr);
   }
   for (i = ((h - 1) % grid_step) / 2; i < h; i += grid_step) {
     cairo_rectangle(cr, 0, i, w, 1);
-    cairo_fill(cr);
   }
+  cairo_fill(cr);
 
   cairo_destroy(cr);
   cr = NULL;

--- a/test_horizontal.c
+++ b/test_horizontal.c
@@ -56,8 +56,8 @@ static void horizontal_draw(GtkWidget *widget) {
   set_color_fg(cr);
   for (i = ((h - 1) % horizontal_step) / 2; i < h; i += horizontal_step) {
     cairo_rectangle(cr, 0, i, w, 1);
-    cairo_fill(cr);
   }
+  cairo_fill(cr);
 
   cairo_destroy(cr);
   cr = NULL;

--- a/test_horizontal.c
+++ b/test_horizontal.c
@@ -55,7 +55,7 @@ static void horizontal_draw(GtkWidget *widget) {
 
   set_color_fg(cr);
   for (i = ((h - 1) % horizontal_step) / 2; i < h; i += horizontal_step) {
-    cairo_rectangle(cr, 0, i, w - 1, 1);
+    cairo_rectangle(cr, 0, i, w, 1);
     cairo_fill(cr);
   }
 

--- a/test_lcdalign.c
+++ b/test_lcdalign.c
@@ -42,12 +42,18 @@ static void lcdalign_draw(GtkWidget *widget) {
   /* Pattern */
   set_color_bg(cr);
   cairo_set_line_width(cr, 1.0);
-  for (i = 1; i < h - 1; i += 1) {
-    cairo_set_dash(cr, d, 1, (i % 2) + 1);
+  cairo_set_dash(cr, d, 1, 0);
+  for (i = 1; i < h - 1; i += 2) {
     cairo_move_to(cr, 1, i + 0.5);
     cairo_line_to(cr, w - 1, i + 0.5);
-    cairo_stroke(cr);
   }
+  cairo_stroke(cr);
+  cairo_set_dash(cr, d, 1, 1);
+  for (i = 2; i < h - 1; i += 2) {
+    cairo_move_to(cr, 1, i + 0.5);
+    cairo_line_to(cr, w - 1, i + 0.5);
+  }
+  cairo_stroke(cr);
 
   cairo_destroy(cr);
   cr = NULL;

--- a/test_text.c
+++ b/test_text.c
@@ -25,71 +25,75 @@
 
 #include "callbacks.h"
 
-static gchar *fontnames[] = {
-    "-adobe-times-medium-r-normal-*-*-80-*-*-p-*-iso8859-1",
-    "-adobe-times-medium-r-normal-*-*-100-*-*-p-*-iso8859-1",
-    "-adobe-times-medium-r-normal-*-*-120-*-*-p-*-iso8859-1",
-    "-adobe-times-medium-r-normal-*-*-140-*-*-p-*-iso8859-1",
-    "-adobe-times-medium-r-normal-*-*-180-*-*-p-*-iso8859-1",
-    "-adobe-times-medium-r-normal-*-*-240-*-*-p-*-iso8859-1",
-    NULL};
+static gint font_sizes[] = {8, 10, 12, 14, 18, 24};
 
-static gint font_num;
+static gint font_size_num;
 
 static gchar text[] =
     "The Screentest home page: https://tobix.github.io/screentest/";
 
-GdkFont *font;
-gint baselineskip, textwidth;
-
-static void font_init(G_GNUC_UNUSED GtkWidget *widget) {
-  gint lbear, rbear, width, asc, desc;
-
-  font = gdk_font_load(fontnames[font_num]);
-
-  if (!font) {
-    printf("Cannot load font %s, trying 'fixed'.\n", fontnames[font_num]);
-    font = gdk_font_load("fixed");
-  }
-
-  gdk_string_extents(font, text, &lbear, &rbear, &width, &asc, &desc);
-  baselineskip = 6 * (asc + desc) / 5; /* 1.2x text height */
-  textwidth = width + baselineskip;    /* the actual width plus space */
-}
-
-static void text_init(GtkWidget *widget) {
-  font_num = 1;
-  font_init(widget);
-}
+static void text_init(GtkWidget *widget) { font_size_num = 1; }
 
 static void text_draw(GtkWidget *widget) {
+  cairo_t *cr;
+  PangoFontDescription *pft;
+  PangoLayout *pl;
   GdkWindow *win = gtk_widget_get_window(widget);
+  GString *dtext;
+  gint i;
+  PangoRectangle ink_rect;
   gint w, h;
-  gint x, y;
+  gint repetitions;
 
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
 
-  x = w + textwidth;
-  for (y = 0; y < h; y += baselineskip)
-    for (x -= w + textwidth; x < w; x += textwidth)
-      gdk_draw_string(win, font, gc, x, y, text);
-}
+  cr = gdk_cairo_create(gtk_widget_get_window(widget));
+  cairo_set_line_width(cr, 1.0);
 
-static void text_close(G_GNUC_UNUSED GtkWidget *widget) {
-  gdk_font_unref(font);
+  pft = pango_font_description_new();
+  pango_font_description_set_size(
+      pft, pango_units_from_double(font_sizes[font_size_num]));
+
+  pl = pango_cairo_create_layout(cr);
+  pango_layout_set_font_description(pl, pft);
+  pango_layout_set_justify(pl, TRUE);
+  pango_layout_set_width(pl, pango_units_from_double(w));
+
+  set_color_bg(cr);
+  cairo_paint(cr);
+
+  set_color_fg(cr);
+
+  pango_layout_set_text(pl, text, -1);
+  pango_layout_get_extents(pl, &ink_rect, NULL);
+  repetitions = (w * h) / (pango_units_to_double(ink_rect.width) *
+                           pango_units_to_double(ink_rect.height));
+
+  dtext = g_string_sized_new(repetitions * (strlen(text) + 1));
+  dtext = g_string_append(dtext, text);
+  for (i = 0; i < repetitions; ++i) {
+    dtext = g_string_append_c(dtext, ' ');
+    dtext = g_string_append(dtext, text);
+  }
+  pango_layout_set_text(pl, dtext->str, -1);
+  pango_cairo_show_layout(cr, pl);
+
+  cairo_destroy(cr);
+  cr = NULL;
+
+  pango_font_description_free(pft);
+  pft = NULL;
 }
 
 static void text_cycle(GtkWidget *widget) {
-  gdk_font_unref(font);
-  if (fontnames[++font_num] == NULL)
-    font_num = 0;
-  font_init(widget);
+  if (++font_size_num == (sizeof(font_sizes) / sizeof(font_sizes[0])))
+    font_size_num = 0;
 }
 
 G_MODULE_EXPORT struct test_ops text_ops = {
     .init = text_init,
     .draw = text_draw,
     .cycle = text_cycle,
-    .close = text_close,
+    .close = NULL,
 };

--- a/test_vertical.c
+++ b/test_vertical.c
@@ -55,7 +55,7 @@ static void vertical_draw(GtkWidget *widget) {
 
   set_color_fg(cr);
   for (i = ((w - 1) % vertical_step) / 2; i < w; i += vertical_step) {
-    cairo_rectangle(cr, i, 0, 1, w - 1);
+    cairo_rectangle(cr, i, 0, 1, h);
     cairo_fill(cr);
   }
 

--- a/test_vertical.c
+++ b/test_vertical.c
@@ -56,8 +56,8 @@ static void vertical_draw(GtkWidget *widget) {
   set_color_fg(cr);
   for (i = ((w - 1) % vertical_step) / 2; i < w; i += vertical_step) {
     cairo_rectangle(cr, i, 0, 1, h);
-    cairo_fill(cr);
   }
+  cairo_fill(cr);
 
   cairo_destroy(cr);
   cr = NULL;


### PR DESCRIPTION
This pull request completes the replacement of the deprecated `GdkGC` by _Cairo_. Furthermore it includes some (very minor) improvements to the rendering.

For all the other tests I tried to be pixel-identical. For `basic` and `text` containing written test I was not able to pull that through. My usage of _Pango_ might be a bit crude, but it gets the job done it seems.