### PR TITLE
Port screentest from GTK+ 2 to 3

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install requirements
-        run: sudo apt-get install intltool libgtk2.0-dev libtool-bin meson
+        run: sudo apt-get install intltool libgtk-3-dev libtool-bin meson
 
       - name: Build
         env:

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 Version 2.2 (Work in Progress)
 
 * Switch build system from Autotools to Meson
+* Upgrade from GTK+ 2 to 3
 
 Version 2.1
 

--- a/callbacks.c
+++ b/callbacks.c
@@ -133,7 +133,7 @@ G_MODULE_EXPORT gboolean on_mainwin_draw_event(
   gdk_window_set_background_rgba(gtk_widget_get_window(widget), bg_color);
 
   if (current_test && current_test->draw)
-    current_test->draw(widget);
+    current_test->draw(widget, cr);
   return TRUE;
 }
 

--- a/callbacks.c
+++ b/callbacks.c
@@ -169,17 +169,15 @@ G_MODULE_EXPORT void on_mode_change(GtkMenuItem *menuitem,
 
 G_MODULE_EXPORT void on_fg_color_activate(G_GNUC_UNUSED GtkMenuItem *menuitem,
                                           G_GNUC_UNUSED gpointer user_data) {
-  GtkColorSelection *colorsel;
   GObject *fg_color_selector;
 
   fg_color_selector = gtk_builder_get_object(builder, "fg_color_selector");
 
-  colorsel = GTK_COLOR_SELECTION(gtk_color_selection_dialog_get_color_selection(
-      GTK_COLOR_SELECTION_DIALOG(fg_color_selector)));
-  gtk_color_selection_set_current_rgba(colorsel, fg_color);
+  gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(fg_color_selector), FALSE);
+  gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(fg_color_selector), fg_color);
   switch (gtk_dialog_run(GTK_DIALOG(fg_color_selector))) {
   case GTK_RESPONSE_OK:
-    gtk_color_selection_get_current_rgba(colorsel, fg_color);
+    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(fg_color_selector), fg_color);
     gdk_window_invalidate_rect(gtk_widget_get_window(mainwin), NULL, FALSE);
     break;
   case GTK_RESPONSE_CANCEL:
@@ -193,17 +191,14 @@ G_MODULE_EXPORT void on_fg_color_activate(G_GNUC_UNUSED GtkMenuItem *menuitem,
 
 G_MODULE_EXPORT void on_bg_color_activate(G_GNUC_UNUSED GtkMenuItem *menuitem,
                                           G_GNUC_UNUSED gpointer user_data) {
-  GtkColorSelection *colorsel;
   GObject *bg_color_selector;
 
   bg_color_selector = gtk_builder_get_object(builder, "bg_color_selector");
-
-  colorsel = GTK_COLOR_SELECTION(gtk_color_selection_dialog_get_color_selection(
-      GTK_COLOR_SELECTION_DIALOG(bg_color_selector)));
-  gtk_color_selection_set_current_rgba(colorsel, bg_color);
+  gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(bg_color_selector), FALSE);
+  gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(bg_color_selector), bg_color);
   switch (gtk_dialog_run(GTK_DIALOG(bg_color_selector))) {
   case GTK_RESPONSE_OK:
-    gtk_color_selection_get_current_rgba(colorsel, bg_color);
+    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(bg_color_selector), bg_color);
     gdk_window_invalidate_rect(gtk_widget_get_window(mainwin), NULL, FALSE);
     break;
   case GTK_RESPONSE_CANCEL:

--- a/callbacks.c
+++ b/callbacks.c
@@ -106,8 +106,12 @@ on_mainwin_button_press_event(GtkWidget *widget, GdkEventButton *event,
     break;
   case 3:
     popup = gtk_builder_get_object(builder, "popup");
+#if GTK_CHECK_VERSION(3, 22, 0)
+    gtk_menu_popup_at_pointer(GTK_MENU(popup), (GdkEvent *)event);
+#else  // GTK_CHECK_VERSION(3,22,0)
     gtk_menu_popup(GTK_MENU(popup), NULL, NULL, NULL, NULL, event->button,
                    event->time);
+#endif // GTK_CHECK_VERSION(3,22,0)
     break;
   }
   return TRUE;

--- a/callbacks.c
+++ b/callbacks.c
@@ -120,11 +120,9 @@ G_MODULE_EXPORT gboolean on_mainwin_key_press_event(
   return FALSE;
 }
 
-G_MODULE_EXPORT gboolean
-on_mainwin_expose_event(GtkWidget *widget, G_GNUC_UNUSED GdkEventExpose *event,
-                        G_GNUC_UNUSED gpointer user_data) {
+G_MODULE_EXPORT gboolean on_mainwin_draw_event(
+    GtkWidget *widget, cairo_t *cr, G_GNUC_UNUSED gpointer user_data) {
   gdk_window_set_background(gtk_widget_get_window(widget), bg_color);
-  gdk_window_clear(gtk_widget_get_window(widget));
 
   if (current_test && current_test->draw)
     current_test->draw(widget);
@@ -161,7 +159,7 @@ G_MODULE_EXPORT void on_mode_change(GtkMenuItem *menuitem,
     if (current_test != NULL && current_test->init != NULL) {
       current_test->init(mainwin);
     }
-    on_mainwin_expose_event(mainwin, NULL, NULL);
+    gtk_widget_queue_draw(mainwin);
   }
 }
 

--- a/callbacks.h
+++ b/callbacks.h
@@ -46,9 +46,9 @@ enum test_color {
 
 #define GRAYS_MAX COLOR_MAX
 
-extern GdkColor fgcolors[];
-extern GdkColor *fg_color;
-extern GdkColor grays[];
+extern GdkRGBA fgcolors[];
+extern GdkRGBA *fg_color;
+extern GdkRGBA grays[];
 
 void set_color_bg(cairo_t *cr);
 void set_color_fg(cairo_t *cr);

--- a/callbacks.h
+++ b/callbacks.h
@@ -25,7 +25,7 @@
 
 struct test_ops {
   void (*init)(GtkWidget *widget);
-  void (*draw)(GtkWidget *widget);
+  void (*draw)(GtkWidget *widget, cairo_t *cr);
   void (*cycle)(GtkWidget *widget);
   void (*close)(GtkWidget *widget);
 };

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project(
 i18n = import('i18n')
 
 gmodule_dep = dependency('gmodule-2.0', version: '>= 1.1.3')
-gtk_dep = dependency('gtk+-2.0', version: '>= 2.24')
+gtk_dep = dependency('gtk+-3.0', version: '>= 3.0')
 screentest_deps = [
   gmodule_dep,
   gtk_dep,

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project(
 i18n = import('i18n')
 
 gmodule_dep = dependency('gmodule-2.0', version: '>= 1.1.3')
-gtk_dep = dependency('gtk+-3.0', version: '>= 3.0')
+gtk_dep = dependency('gtk+-3.0', version: '>= 3.4')
 screentest_deps = [
   gmodule_dep,
   gtk_dep,

--- a/screentest.ui
+++ b/screentest.ui
@@ -17,65 +17,19 @@
       <placeholder/>
     </child>
   </object>
-  <object class="GtkColorSelectionDialog" id="fg_color_selector">
+  <object class="GtkColorChooserDialog" id="fg_color_selector">
     <property name="title" translatable="yes">Select Foreground color</property>
     <property name="resizable">False</property>
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
     <property name="transient_for">mainwin</property>
-    <child internal-child="color_selection">
-      <object class="GtkColorSelection" id="fg_color_selection">
-        <property name="has_palette">True</property>
-      </object>
-    </child>
-    <child internal-child="help_button">
-      <object class="GtkButton" id="fg_color_help">
-        <property name="can_focus">False</property>
-        <property name="receives_default">False</property>
-      </object>
-    </child>
-    <child internal-child="cancel_button">
-      <object class="GtkButton" id="fg_color_cancel">
-        <property name="can_focus">False</property>
-        <property name="receives_default">False</property>
-      </object>
-    </child>
-    <child internal-child="ok_button">
-      <object class="GtkButton" id="fg_color_ok">
-        <property name="can_focus">False</property>
-        <property name="receives_default">False</property>
-      </object>
-    </child>
   </object>
-  <object class="GtkColorSelectionDialog" id="bg_color_selector">
+  <object class="GtkColorChooserDialog" id="bg_color_selector">
     <property name="title" translatable="yes">Select Background color</property>
     <property name="resizable">False</property>
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
     <property name="transient_for">mainwin</property>
-    <child internal-child="color_selection">
-      <object class="GtkColorSelection" id="bg_color_selection">
-        <property name="has_palette">True</property>
-      </object>
-    </child>
-    <child internal-child="help_button">
-      <object class="GtkButton" id="bg_color_help">
-        <property name="can_focus">False</property>
-        <property name="receives_default">False</property>
-      </object>
-    </child>
-    <child internal-child="cancel_button">
-      <object class="GtkButton" id="bg_color_cancel">
-        <property name="can_focus">False</property>
-        <property name="receives_default">False</property>
-      </object>
-    </child>
-    <child internal-child="ok_button">
-      <object class="GtkButton" id="bg_color_ok">
-        <property name="can_focus">False</property>
-        <property name="receives_default">False</property>
-      </object>
-    </child>
   </object>
   <object class="GtkMenu" id="popup">
     <property name="visible">True</property>

--- a/screentest.ui
+++ b/screentest.ui
@@ -9,7 +9,7 @@
     <accel-groups>
       <group name="accelgroup1"/>
     </accel-groups>
-    <signal name="expose_event" handler="on_mainwin_expose_event"/>
+    <signal name="draw" handler="on_mainwin_draw_event"/>
     <signal name="button_press_event" handler="on_mainwin_button_press_event"/>
     <signal name="realize" handler="on_mainwin_realize"/>
     <signal name="delete_event" handler="gtk_main_quit"/>

--- a/test_basic.c
+++ b/test_basic.c
@@ -48,8 +48,7 @@ static void draw_boxes(cairo_t *cr, GdkRGBA *colors, gint ncols, gint x, gint y,
   set_color_fg(cr);
 }
 
-static void basic_draw(GtkWidget *widget) {
-  cairo_t *cr;
+static void basic_draw(GtkWidget *widget, cairo_t *cr) {
   PangoLayout *pl;
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
@@ -70,7 +69,6 @@ static void basic_draw(GtkWidget *widget) {
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
 
-  cr = gdk_cairo_create(gtk_widget_get_window(widget));
   cairo_set_line_width(cr, 1.0);
 
   pl = pango_cairo_create_layout(cr);
@@ -162,9 +160,6 @@ static void basic_draw(GtkWidget *widget) {
   cairo_new_sub_path(cr);
   cairo_arc(cr, w / 2, h / 2, d, 0, 2 * G_PI);
   cairo_stroke(cr);
-
-  cairo_destroy(cr);
-  cr = NULL;
 }
 
 G_MODULE_EXPORT struct test_ops basic_ops = {

--- a/test_basic.c
+++ b/test_basic.c
@@ -31,16 +31,14 @@
 
 #define BASIC_STEP 40
 
-static void draw_boxes(cairo_t *cr, GdkColor *colors, gint ncols, gint x,
-                       gint y, gint d) {
-  GdkColor *col;
+static void draw_boxes(cairo_t *cr, GdkRGBA *colors, gint ncols, gint x, gint y,
+                       gint d) {
+  GdkRGBA *col;
   int i;
 
   for (i = 0; i < ncols; i++) {
     col = &colors[i];
-    cairo_set_source_rgb(cr, col->red / (double)UINT16_MAX,
-                         col->green / (double)UINT16_MAX,
-                         col->blue / (double)UINT16_MAX);
+    cairo_set_source_rgb(cr, col->red, col->green, col->blue);
 
     cairo_rectangle(cr, x, y, d, d);
     cairo_fill(cr);

--- a/test_blink.c
+++ b/test_blink.c
@@ -32,8 +32,7 @@ static gint blink_step;
 void (*set_color1)(cairo_t *cr);
 void (*set_color2)(cairo_t *cr);
 
-static void blink_draw(GtkWidget *widget) {
-  cairo_t *cr;
+static void blink_draw(GtkWidget *widget, cairo_t *cr) {
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
 
@@ -47,8 +46,6 @@ static void blink_draw(GtkWidget *widget) {
     set_color1 = set_color_fg;
     set_color2 = set_color_bg;
   }
-
-  cr = gdk_cairo_create(gtk_widget_get_window(widget));
 
   set_color_fg(cr);
   cairo_paint(cr);
@@ -78,9 +75,6 @@ static void blink_draw(GtkWidget *widget) {
     cairo_rectangle(cr, 5, 2 * h / 3, w - 10, h / 3 - 5);
     cairo_fill(cr);
   }
-
-  cairo_destroy(cr);
-  cr = NULL;
 }
 
 static gboolean blink_timeout(gpointer data) {

--- a/test_blink.c
+++ b/test_blink.c
@@ -86,7 +86,9 @@ static void blink_draw(GtkWidget *widget) {
 static gboolean blink_timeout(gpointer data) {
   GtkWidget *widget = (GtkWidget *)data;
   blink_step = !blink_step;
-  blink_draw(widget);
+
+  gtk_widget_queue_draw(widget);
+
   return TRUE;
 }
 

--- a/test_bright_pixels.c
+++ b/test_bright_pixels.c
@@ -40,18 +40,12 @@ static void bright_pixels_cycle(G_GNUC_UNUSED GtkWidget *widget) {
     current_color_idx = 0;
 }
 
-static void bright_pixels_draw(GtkWidget *widget) {
+static void bright_pixels_draw(GtkWidget *widget, cairo_t *cr) {
   GdkRGBA *col;
-  cairo_t *cr;
-
-  cr = gdk_cairo_create(gtk_widget_get_window(widget));
 
   col = &fgcolors[color_cycle[current_color_idx]];
   cairo_set_source_rgb(cr, col->red, col->green, col->blue);
   cairo_paint(cr);
-
-  cairo_destroy(cr);
-  cr = NULL;
 }
 
 G_MODULE_EXPORT struct test_ops bright_pixels_ops = {.init = bright_pixels_init,

--- a/test_bright_pixels.c
+++ b/test_bright_pixels.c
@@ -41,15 +41,13 @@ static void bright_pixels_cycle(G_GNUC_UNUSED GtkWidget *widget) {
 }
 
 static void bright_pixels_draw(GtkWidget *widget) {
-  GdkColor *col;
+  GdkRGBA *col;
   cairo_t *cr;
 
   cr = gdk_cairo_create(gtk_widget_get_window(widget));
 
   col = &fgcolors[color_cycle[current_color_idx]];
-  cairo_set_source_rgb(cr, col->red / (double)UINT16_MAX,
-                       col->green / (double)UINT16_MAX,
-                       col->blue / (double)UINT16_MAX);
+  cairo_set_source_rgb(cr, col->red, col->green, col->blue);
   cairo_paint(cr);
 
   cairo_destroy(cr);

--- a/test_grid.c
+++ b/test_grid.c
@@ -39,16 +39,13 @@ static void grid_cycle(G_GNUC_UNUSED GtkWidget *widget) {
     grid_step = GRID_STEP;
 }
 
-static void grid_draw(GtkWidget *widget) {
-  cairo_t *cr;
+static void grid_draw(GtkWidget *widget, cairo_t *cr) {
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
   gint i;
 
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
-
-  cr = gdk_cairo_create(gtk_widget_get_window(widget));
 
   set_color_bg(cr);
   cairo_paint(cr);
@@ -61,9 +58,6 @@ static void grid_draw(GtkWidget *widget) {
     cairo_rectangle(cr, 0, i, w, 1);
   }
   cairo_fill(cr);
-
-  cairo_destroy(cr);
-  cr = NULL;
 }
 
 G_MODULE_EXPORT struct test_ops grid_ops = {

--- a/test_horizontal.c
+++ b/test_horizontal.c
@@ -39,16 +39,13 @@ static void horizontal_cycle(G_GNUC_UNUSED GtkWidget *widget) {
     horizontal_step = GRID_STEP;
 }
 
-static void horizontal_draw(GtkWidget *widget) {
-  cairo_t *cr;
+static void horizontal_draw(GtkWidget *widget, cairo_t *cr) {
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
   gint i;
 
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
-
-  cr = gdk_cairo_create(gtk_widget_get_window(widget));
 
   set_color_bg(cr);
   cairo_paint(cr);
@@ -58,9 +55,6 @@ static void horizontal_draw(GtkWidget *widget) {
     cairo_rectangle(cr, 0, i, w, 1);
   }
   cairo_fill(cr);
-
-  cairo_destroy(cr);
-  cr = NULL;
 }
 
 G_MODULE_EXPORT struct test_ops horizontal_ops = {.init = horizontal_init,

--- a/test_lcdalign.c
+++ b/test_lcdalign.c
@@ -23,8 +23,7 @@
 
 #include "callbacks.h"
 
-static void lcdalign_draw(GtkWidget *widget) {
-  cairo_t *cr;
+static void lcdalign_draw(GtkWidget *widget, cairo_t *cr) {
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
   gint i;
@@ -32,8 +31,6 @@ static void lcdalign_draw(GtkWidget *widget) {
 
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
-
-  cr = gdk_cairo_create(gtk_widget_get_window(widget));
 
   /* Background/Border */
   set_color_fg(cr);
@@ -54,9 +51,6 @@ static void lcdalign_draw(GtkWidget *widget) {
     cairo_line_to(cr, w - 1, i + 0.5);
   }
   cairo_stroke(cr);
-
-  cairo_destroy(cr);
-  cr = NULL;
 }
 
 G_MODULE_EXPORT struct test_ops lcdalign_ops = {

--- a/test_text.c
+++ b/test_text.c
@@ -34,8 +34,7 @@ static gchar text[] =
 
 static void text_init(GtkWidget *widget) { font_size_num = 1; }
 
-static void text_draw(GtkWidget *widget) {
-  cairo_t *cr;
+static void text_draw(GtkWidget *widget, cairo_t *cr) {
   PangoFontDescription *pft;
   PangoLayout *pl;
   GdkWindow *win = gtk_widget_get_window(widget);
@@ -48,7 +47,6 @@ static void text_draw(GtkWidget *widget) {
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
 
-  cr = gdk_cairo_create(gtk_widget_get_window(widget));
   cairo_set_line_width(cr, 1.0);
 
   pft = pango_font_description_new();
@@ -78,9 +76,6 @@ static void text_draw(GtkWidget *widget) {
   }
   pango_layout_set_text(pl, dtext->str, -1);
   pango_cairo_show_layout(cr, pl);
-
-  cairo_destroy(cr);
-  cr = NULL;
 
   pango_font_description_free(pft);
   pft = NULL;

--- a/test_vertical.c
+++ b/test_vertical.c
@@ -39,16 +39,13 @@ static void vertical_cycle(G_GNUC_UNUSED GtkWidget *widget) {
     vertical_step = GRID_STEP;
 }
 
-static void vertical_draw(GtkWidget *widget) {
-  cairo_t *cr;
+static void vertical_draw(GtkWidget *widget, cairo_t *cr) {
   GdkWindow *win = gtk_widget_get_window(widget);
   gint w, h;
   gint i;
 
   h = gdk_window_get_height(win);
   w = gdk_window_get_width(win);
-
-  cr = gdk_cairo_create(gtk_widget_get_window(widget));
 
   set_color_bg(cr);
   cairo_paint(cr);
@@ -58,9 +55,6 @@ static void vertical_draw(GtkWidget *widget) {
     cairo_rectangle(cr, i, 0, 1, h);
   }
   cairo_fill(cr);
-
-  cairo_destroy(cr);
-  cr = NULL;
 }
 
 G_MODULE_EXPORT struct test_ops vertical_ops = {.init = vertical_init,


### PR DESCRIPTION
This pull request conducts the minimum changes necessary to port _screentest_ from _GTK+_ _2_ to _3_.

In summary the following changes are being conducted:
* update dependency on GTK+ in Meson from `gtk+-2.0` to `gtk+-3.0` (at least in version `3.4`, which was released in 2012 and should be a sane baseline in 2024)
* move the test drawing from happening on an `expose` event to the `draw` handler introduced by GTK+ 3
* replace deprecated `GdkColor` by `GdkRGBA`
* replace deprecated `GtkColorSelectionDialog` by `GtkColorChooserDialog`
* (optionally) replace deprecated `gtk_menu_popup` by `gtk_menu_popup_at_pointer`
* drop now superfluous `gdk_cairo_create` and `cairo_destroy` invocations